### PR TITLE
Document optional dependencies for Overview notebook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,13 @@ extras_require = {
             'geopandas',
             'hilbertcurve'
       ],
+      'examples': [
+            'geopandas',
+            'matplotlib',
+            'descartes',
+            'datashader',
+            'holoviews',
+      ]
 }
 
 install_requires = [


### PR DESCRIPTION
Closes https://github.com/holoviz/spatialpandas/issues/15 by adding the example dependencies to `extras_require` in setup.py, and as a comment in the Overview notebook.