### PR TITLE
Add pack partitions to parquet method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
       'numpy',
       'pyarrow>=0.15',
       'param',
+      'fsspec',
 ]
 
 setup(name='spatialpandas',

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -169,9 +169,6 @@ class DaskGeoDataFrame(dd.DataFrame):
             # happen to be already sorted
             ddf = ddf.repartition(npartitions=npartitions)
 
-        # Trigger calculation of partition bounds and spatial index
-        ddf.partition_sindex
-
         return ddf
 
     # Override some standard Dask Dataframe methods to propagate extra properties

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -313,9 +313,9 @@ class DaskGeoDataFrame(dd.DataFrame):
             (pp, wi) for (pp, wi) in zip(part_paths, write_info) if wi is not None
         ])
         output_paths = part_paths[:len(input_paths)]
-        move_tasks = [dask.delayed(filesystem.move)(p1, p2)
-                      for p1, p2 in zip(input_paths, output_paths) if p1 != p2]
-        dask.compute(*move_tasks)
+        for p1, p2 in zip(input_paths, output_paths):
+            if p1 != p2:
+                filesystem.move(p1, p2)
 
         # Write _metadata
         meta = write_info[0]['meta']

--- a/spatialpandas/geoseries.py
+++ b/spatialpandas/geoseries.py
@@ -58,7 +58,7 @@ class GeoSeries(pd.Series):
     def length(self):
         return pd.Series(self.array.length, index=self.index)
 
-    def hilbert_distance(self, total_bounds=None, p=10):
+    def hilbert_distance(self, total_bounds=None, p=15):
         return pd.Series(
             self.array.hilbert_distance(total_bounds=total_bounds, p=p),
             index=self.index

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -108,6 +108,10 @@ def to_parquet_dask(ddf, path, compression="default", storage_options=None, **kw
     for series_name in ddf.columns:
         series = ddf[series_name]
         if isinstance(series.dtype, GeometryDtype):
+            if series._partition_bounds is None:
+                # Bounds are not already computed. Compute bounds from the parquet file
+                # that was just written.
+                series = read_parquet_dask(path, columns=[series_name])[series_name]
             partition_bounds[series_name] = series.partition_bounds.to_dict()
 
     spatial_metadata = {'partition_bounds': partition_bounds}

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -39,7 +39,9 @@ def _load_parquet_pandas_metadata(path, filesystem=None):
         raise ValueError("Path not found: " + path)
 
     if filesystem.isdir(path):
-        pqds = pa.parquet.ParquetDataset(path, filesystem=filesystem)
+        pqds = pa.parquet.ParquetDataset(
+            path, filesystem=filesystem, validate_schema=False
+        )
         common_metadata = pqds.common_metadata
         if common_metadata is None:
             # Get metadata for first piece
@@ -93,7 +95,7 @@ def read_parquet(path, columns=None, filesystem=None):
 
     # Load using pyarrow to handle parquet files and directories across filesystems
     df = pa.parquet.ParquetDataset(
-        path, filesystem=filesystem
+        path, filesystem=filesystem, validate_schema=False
     ).read().to_pandas()
 
     if columns:
@@ -142,7 +144,7 @@ def to_parquet_dask(
     spatial_metadata = {'partition_bounds': partition_bounds}
     b_spatial_metadata = json.dumps(spatial_metadata).encode('utf')
 
-    pqds = pq.ParquetDataset(path)
+    pqds = pq.ParquetDataset(path, validate_schema=False)
     all_metadata = copy.copy(pqds.common_metadata.metadata)
     all_metadata[b'spatialpandas'] = b_spatial_metadata
     schema = pqds.common_metadata.schema.to_arrow_schema()
@@ -183,7 +185,7 @@ def read_parquet_dask(
         result.divisions,
     )
     # Load bounding box info from _metadata
-    pqds = pq.ParquetDataset(path, filesystem=filesystem)
+    pqds = pq.ParquetDataset(path, filesystem=filesystem, validate_schema=False)
     if b'spatialpandas' in pqds.common_metadata.metadata:
         spatial_metadata = json.loads(
             pqds.common_metadata.metadata[b'spatialpandas'].decode('utf')

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -39,7 +39,7 @@ def _load_parquet_pandas_metadata(path, filesystem=None):
         raise ValueError("Path not found: " + path)
 
     if filesystem.isdir(path):
-        pqds = pa.parquet.ParquetDataset(
+        pqds = pq.ParquetDataset(
             path, filesystem=filesystem, validate_schema=False
         )
         common_metadata = pqds.common_metadata
@@ -51,7 +51,7 @@ def _load_parquet_pandas_metadata(path, filesystem=None):
             metadata = pqds.common_metadata.metadata
     else:
         with filesystem.open(path) as f:
-            pf = pa.parquet.ParquetFile(f)
+            pf = pq.ParquetFile(f)
         metadata = pf.metadata.metadata
 
     return json.loads(
@@ -94,7 +94,7 @@ def read_parquet(path, columns=None, filesystem=None):
     filesystem = validate_coerce_filesystem(path, filesystem)
 
     # Load using pyarrow to handle parquet files and directories across filesystems
-    df = pa.parquet.ParquetDataset(
+    df = pq.ParquetDataset(
         path, filesystem=filesystem, validate_schema=False
     ).read().to_pandas()
 

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -144,7 +144,7 @@ def to_parquet_dask(
     spatial_metadata = {'partition_bounds': partition_bounds}
     b_spatial_metadata = json.dumps(spatial_metadata).encode('utf')
 
-    pqds = pq.ParquetDataset(path, validate_schema=False)
+    pqds = pq.ParquetDataset(path, filesystem=filesystem, validate_schema=False)
     all_metadata = copy.copy(pqds.common_metadata.metadata)
     all_metadata[b'spatialpandas'] = b_spatial_metadata
     schema = pqds.common_metadata.schema.to_arrow_schema()

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -149,7 +149,8 @@ def to_parquet_dask(
     all_metadata[b'spatialpandas'] = b_spatial_metadata
     schema = pqds.common_metadata.schema.to_arrow_schema()
     new_schema = schema.with_metadata(all_metadata)
-    pq.write_metadata(new_schema, pqds.common_metadata_path)
+    with filesystem.open(pqds.common_metadata_path, 'wb') as f:
+        pq.write_metadata(new_schema, f)
 
 
 def read_parquet_dask(

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -40,7 +40,13 @@ def _load_parquet_pandas_metadata(path):
 
     if os.path.isdir(path):
         pqds = pa.parquet.ParquetDataset(path)
-        metadata = pqds.common_metadata.metadata
+        common_metadata = pqds.common_metadata
+        if common_metadata is None:
+            # Get metadata for first piece
+            piece = pqds.pieces[0]
+            metadata = piece.get_metadata().metadata
+        else:
+            metadata = pqds.common_metadata.metadata
     else:
         pf = pa.parquet.ParquetFile(path)
         metadata = pf.metadata.metadata

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -130,7 +130,13 @@ def to_parquet_dask(
             if series._partition_bounds is None:
                 # Bounds are not already computed. Compute bounds from the parquet file
                 # that was just written.
-                series = read_parquet_dask(path, columns=[series_name])[series_name]
+                filesystem.invalidate_cache(path)
+                series = read_parquet_dask(
+                    path,
+                    columns=[series_name],
+                    filesystem=filesystem,
+                    storage_options=storage_options,
+                )[series_name]
             partition_bounds[series_name] = series.partition_bounds.to_dict()
 
     spatial_metadata = {'partition_bounds': partition_bounds}

--- a/spatialpandas/io/utils.py
+++ b/spatialpandas/io/utils.py
@@ -8,7 +8,7 @@ def validate_coerce_filesystem(path, filesystem=None):
     Args:
         path: Path as a string
         filesystem: Optional fsspec filesystem object to use to open the file. If not
-            provided, filesystem type is infered from path
+            provided, filesystem type is inferred from path
 
     Returns:
         fsspec file system

--- a/spatialpandas/io/utils.py
+++ b/spatialpandas/io/utils.py
@@ -1,0 +1,28 @@
+import fsspec
+
+
+def validate_coerce_filesystem(path, filesystem=None):
+    """
+    Validate filesystem argument and return an fsspec file system object
+
+    Args:
+        path: Path as a string
+        filesystem: Optional fsspec filesystem object to use to open the file. If not
+            provided, filesystem type is infered from path
+
+    Returns:
+        fsspec file system
+    """
+    if filesystem is None:
+        return fsspec.open(path).fs
+    else:
+        if isinstance(filesystem, str):
+            return fsspec.filesystem(filesystem)
+        elif isinstance(filesystem, fsspec.AbstractFileSystem):
+            return filesystem
+        else:
+            raise ValueError(
+                "Received invalid filesystem value with type: {typ}".format(
+                    typ=type(filesystem)
+                )
+            )


### PR DESCRIPTION
This PR adds a new `DaskGeoDataFrame.pack_partitions_to_parquet` method.  This method is equivalent to chaining `pack_partitions` and `to_parquet`, but it has lower memory requirements.


