### PR TITLE
Add glob support and bounding box filter to read_parquet_dask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.2.0
+=============
+
+### Added
+ - Added `pack_partitions_to_parquet` method to `DaskGeoDataFrame` ([#19](https://github.com/holoviz/spatialpandas/pull/19))
+ - Added support for remote filesystems using the `fsspec` library ([#19](https://github.com/holoviz/spatialpandas/pull/19))
+
 Version 0.1.1
 =============
 

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -17,8 +17,6 @@ import uuid
 import json
 import copy
 
-from .io.utils import validate_coerce_filesystem
-
 
 class DaskGeoSeries(dd.Series):
     def __init__(self, dsk, name, meta, divisions, *args, **kwargs):
@@ -208,6 +206,7 @@ class DaskGeoDataFrame(dd.DataFrame):
             DaskGeoDataFrame backed by newly written parquet dataset
         """
         from .io import read_parquet, read_parquet_dask
+        from .io.utils import validate_coerce_filesystem
 
         # Get fsspec filesystem object
         filesystem = validate_coerce_filesystem(path, filesystem)

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -168,7 +168,24 @@ def to_parquet_dask(
 def read_parquet_dask(
         path, columns=None, filesystem=None, load_divisions=False, **kwargs
 ):
-    # Infer load_divisions and normalize path to a list
+    """
+    Read spatialpandas parquet dataset(s) as DaskGeoDataFrame. Datasets are assumed to
+    have been written with the DaskGeoDataFrame.to_parquet or
+    DaskGeoDataFrame.pack_partitions_to_parquet methods.
+
+    Args:
+        path: Path to spatialpandas parquet dataset, or list of paths to datasets, or
+            glob string referencing one or more parquet datasets.
+        columns: List of columns to load
+        filesystem: fsspec filesystem to use to read datasets
+        load_divisions: If True, attempt to load the hilbert_distance divisions for
+            each partition.  Only available for datasets written using the
+            pack_partitions_to_parquet method.
+
+    Returns:
+    DaskGeoDataFrame
+    """
+    # Normalize path to a list
     if isinstance(path, (str, pathlib.Path)):
         path = [str(path)]
     else:

--- a/spatialpandas/io/utils.py
+++ b/spatialpandas/io/utils.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import fsspec
 
 
@@ -16,8 +18,8 @@ def validate_coerce_filesystem(path, filesystem=None):
     if filesystem is None:
         return fsspec.open(path).fs
     else:
-        if isinstance(filesystem, str):
-            return fsspec.filesystem(filesystem)
+        if isinstance(filesystem, (str, pathlib.Path)):
+            return fsspec.filesystem(str(filesystem))
         elif isinstance(filesystem, fsspec.AbstractFileSystem):
             return filesystem
         else:

--- a/tests/test_dask_autoimport.py
+++ b/tests/test_dask_autoimport.py
@@ -1,0 +1,13 @@
+import spatialpandas as sp
+import dask.dataframe as dd
+import pandas as pd
+
+
+def test_dask_registration():
+    ddf = dd.from_pandas(sp.GeoDataFrame({
+        'geom': pd.array(
+            [[0, 0], [0, 1, 1, 1], [0, 2, 1, 2, 2, 2]], dtype='MultiPoint[float64]'),
+        'v': [1, 2, 3]
+    }), npartitions=3)
+    assert isinstance(ddf, sp.dask.DaskGeoDataFrame)
+

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -5,7 +5,7 @@ from spatialpandas import GeoSeries, GeoDataFrame
 from spatialpandas.dask import DaskGeoDataFrame
 from tests.geometry.strategies import (
     st_multipoint_array, st_multiline_array,
-    st_point_array)
+    st_point_array, st_bounds)
 import numpy as np
 from spatialpandas.io import (
     to_parquet, read_parquet, read_parquet_dask, to_parquet_dask
@@ -222,3 +222,94 @@ def test_pack_partitions_to_parquet_glob(
     )
 
     assert ddf_globbed.geometry.name == 'lines'
+
+
+@given(
+    gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
+    gp_multiline1=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
+    gp_multiline2=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    bounds=st_bounds(),
+)
+@settings(deadline=None, max_examples=30)
+def test_pack_partitions_to_parquet_list_bounds(
+        gp_multipoint1, gp_multiline1,
+        gp_multipoint2, gp_multiline2,
+        bounds, tmp_path,
+):
+    # Build dataframe1
+    n = min(len(gp_multipoint1), len(gp_multiline1))
+    df1 = GeoDataFrame({
+        'points': GeoSeries(gp_multipoint1[:n]),
+        'lines': GeoSeries(gp_multiline1[:n]),
+        'a': list(range(n))
+    }).set_geometry('lines')
+    ddf1 = dd.from_pandas(df1, npartitions=3)
+    path1 = tmp_path / 'ddf1.parq'
+    ddf_packed1 = ddf1.pack_partitions_to_parquet(path1, npartitions=3)
+
+    # Build dataframe2
+    n = min(len(gp_multipoint2), len(gp_multiline2))
+    df2 = GeoDataFrame({
+        'points': GeoSeries(gp_multipoint2[:n]),
+        'lines': GeoSeries(gp_multiline2[:n]),
+        'a': list(range(n))
+    }).set_geometry('lines')
+    ddf2 = dd.from_pandas(df2, npartitions=3)
+    path2 = tmp_path / 'ddf2.parq'
+    ddf_packed2 = ddf2.pack_partitions_to_parquet(path2, npartitions=4)
+
+    # Load both packed datasets with glob
+    ddf_read = read_parquet_dask(
+        [tmp_path / "ddf1.parq", tmp_path / "ddf2.parq"],
+        geometry="points", bounds=bounds
+    )
+
+    # Check the number of partitions (< 7 can happen in the case of empty partitions)
+    assert ddf_read.npartitions <= 7
+
+    # Check contents
+    xslice = slice(bounds[0], bounds[2])
+    yslice = slice(bounds[1], bounds[3])
+    expected_df = pd.concat([
+        ddf_packed1.cx_partitions[xslice, yslice].compute(),
+        ddf_packed2.cx_partitions[xslice, yslice].compute()
+    ])
+    df_read = ddf_read.compute()
+    pd.testing.assert_frame_equal(df_read, expected_df)
+
+    # Compute expected partition bounds
+    points_bounds = pd.concat([
+        ddf_packed1._partition_bounds['points'],
+        ddf_packed2._partition_bounds['points'],
+    ]).reset_index(drop=True)
+
+    x0, y0, x1, y1 = bounds
+    x0, x1 = (x0, x1) if x0 <= x1 else (x1, x0)
+    y0, y1 = (y0, y1) if y0 <= y1 else (y1, y0)
+    partition_inds = ~(
+        (points_bounds.x1 < x0) |
+        (points_bounds.y1 < y0) |
+        (points_bounds.x0 > x1) |
+        (points_bounds.y0 > y1)
+    )
+    points_bounds = points_bounds[partition_inds].reset_index(drop=True)
+
+    lines_bounds = pd.concat([
+        ddf_packed1._partition_bounds['lines'],
+        ddf_packed2._partition_bounds['lines'],
+    ]).reset_index(drop=True)[partition_inds].reset_index(drop=True)
+    points_bounds.index.name = 'partition'
+    lines_bounds.index.name = 'partition'
+
+    # Check partition bounds
+    pd.testing.assert_frame_equal(
+        points_bounds, ddf_read._partition_bounds['points']
+    )
+
+    pd.testing.assert_frame_equal(
+        lines_bounds, ddf_read._partition_bounds['lines']
+    )
+
+    # Check active geometry column
+    assert ddf_read.geometry.name == 'points'

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -179,9 +179,9 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline, tmp_path):
 
     # Read columns
     columns = ['a', 'lines']
-    ddf_read_cols = read_parquet_dask(path, columns=columns)
+    ddf_read_cols = read_parquet_dask(path, columns=columns + ['hilbert_distance'])
     pd.testing.assert_frame_equal(
-        ddf_read_cols.compute(), df[columns]
+        ddf_read_cols.compute(), ddf_packed[columns].compute()
     )
 
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -81,6 +81,7 @@ def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path):
         ddf_read._partition_bounds['lines'],
     )
 
+    assert ddf_read.geometry.name == 'points'
 
 @given(
     gp_multipoint=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
@@ -151,6 +152,8 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline, tmp_path):
 
     np.testing.assert_equal(expected_distances, hilbert_distances)
 
+    assert ddf_packed.geometry.name == 'points'
+
 
 @given(
     gp_multipoint1=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
@@ -187,7 +190,7 @@ def test_pack_partitions_to_parquet_glob(
     ddf_packed2 = ddf2.pack_partitions_to_parquet(path2, npartitions=4)
 
     # Load both packed datasets with glob
-    ddf_globbed = read_parquet_dask(tmp_path / "ddf*.parq")
+    ddf_globbed = read_parquet_dask(tmp_path / "ddf*.parq", geometry="lines")
 
     # Check the number of partitions (< 7 can happen in the case of empty partitions)
     assert ddf_globbed.npartitions <= 7
@@ -217,3 +220,5 @@ def test_pack_partitions_to_parquet_glob(
     pd.testing.assert_frame_equal(
         expected_bounds['lines'], ddf_globbed._partition_bounds['lines']
     )
+
+    assert ddf_globbed.geometry.name == 'lines'


### PR DESCRIPTION
This PR rewrites `read_parquet_dask` to:
 - Add support for specifying a list of paths or a glob string path that matches 1 or more paths.  
 - Add a `bounds` argument to restrict partitions to those that intersect with the specified bounding box

It also adds a fix and test to make sure that the `DaskGeoDataFrame` is registered with Dask when `spatialpandas` is imported.