### PR TITLE
Add temp_format argument to pack_partitions_to_parquet

### DIFF
--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -317,8 +317,9 @@ class DaskGeoDataFrame(dd.DataFrame):
                     total_bounds[series_name] = series.total_bounds
 
             # Delete directory of parquet parts for partition
-            filesystem.rm(parts_tmp_path, recursive=True)
-            if part_output_path != parts_tmp_path:
+            if filesystem.exists(parts_tmp_path):
+                filesystem.rm(parts_tmp_path, recursive=True)
+            if filesystem.exists(part_output_path):
                 filesystem.rm(part_output_path, recursive=True)
 
             # Sort by part_df by hilbert_distance index

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -377,8 +377,8 @@ def _load_divisions(pqds):
         )
 
     mins, maxes = zip(*[
-        (rg.column(div_col).statistics.min, rg.column(12).statistics.max)
+        (rg.column(div_col).statistics.min, rg.column(div_col).statistics.max)
         for rg in row_groups
     ])
 
-    return mins, maxes
+    return list(mins), list(maxes)

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -259,9 +259,17 @@ def _perform_read_parquet_dask(
         partition_bounds = {}
 
     # Use Dask's read_parquet to get metadata
+    if columns is not None:
+        cols_no_index = [col for col in columns if col != "hilbert_distance"]
+    else:
+        cols_no_index = None
+
     meta = dd_read_parquet(
-        paths[0], columns=columns, filesystem=filesystem,
-        engine='pyarrow', gather_statistics=False
+        paths[0],
+        columns=cols_no_index,
+        filesystem=filesystem,
+        engine='pyarrow',
+        gather_statistics=False
     )._meta
 
     # Import geometry columns in meta, not needed for pyarrow >= 0.16

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -163,7 +163,7 @@ def test_pack_partitions_to_parquet(
 
     path = tmp_path / 'ddf.parq'
     if use_temp_format:
-        tempdir_format = str(tmp_path / 'scratch' / 'part-{partition:03d}')
+        tempdir_format = str(tmp_path / 'scratch' / 'part-{uuid}-{partition:03d}')
     else:
         tempdir_format = None
 


### PR DESCRIPTION
This PR adds a new argument to `DaskGeoDataFrame.pack_partitions_to_parquet` named `temp_format`.  This argument may be set to a format string containing a `{partition}` replacement field. If provided, this string is formatted with the output partition number to generate the temporary directory path for that partition.

For example `temp_format="/tmp/spatial/part-{partition}"` would create temporary directories:
 -  `/tmp/spatial/part-0`
 -  `/tmp/spatial/part-1`
 -  `/tmp/spatial/part-2`
...

The `temp_format` string may also contain a `{uuid}` replacement field. If provided this will be replaced by a randomly generated UUID string.  This makes it possible to reuse the same `temp_format` string in multiple simultaneous jobs without conflict.

