### PR TITLE
spatial join Dask updates

### DIFF
--- a/spatialpandas/spatialindex/rtree.py
+++ b/spatialpandas/spatialindex/rtree.py
@@ -179,7 +179,7 @@ class HilbertRtree:
         self._page_size = max(1, page_size)  # 1 is smallest valid page size
         self._numba_rtree = None
         self._sorted_bounds, self._keys, self._bounds_tree = \
-            HilbertRtree._build_hilbert_rtree(bounds, p, self._page_size)
+            HilbertRtree._build_hilbert_rtree(bounds.astype('float64'), p, self._page_size)
 
     def __getstate__(self):
         # Remove _NumbaRtree instance during serialization since jitclass instances

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -144,8 +144,8 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
 
 
 @given(
-    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
-    gp_multiline=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+    gp_multipoint=st_multipoint_array(min_size=60, max_size=100, geoseries=True),
+    gp_multiline=st_multiline_array(min_size=60, max_size=100, geoseries=True),
     use_temp_format=hs.booleans()
 )
 @settings(deadline=None, max_examples=30)
@@ -168,12 +168,12 @@ def test_pack_partitions_to_parquet(
         tempdir_format = None
 
     ddf_packed = ddf.pack_partitions_to_parquet(
-        path, npartitions=4,
+        path, npartitions=12,
         tempdir_format=tempdir_format
     )
 
     # Check the number of partitions (< 4 can happen in the case of empty partitions)
-    assert ddf_packed.npartitions <= 4
+    assert ddf_packed.npartitions <= 12
 
     # Check that rows are now sorted in order of hilbert distance
     total_bounds = df.lines.total_bounds

--- a/tests/tools/test_sjoin.py
+++ b/tests/tools/test_sjoin.py
@@ -53,8 +53,8 @@ def test_sjoin(gp_points, gp_polygons, how):
     assert isinstance(result, GeoDataFrame)
 
     # Check pandas results
-    if len(result) == 0:
-        assert len(gp_expected) == 0
+    if len(gp_expected) == 0:
+        assert len(result) == 0
     else:
         expected = GeoDataFrame(gp_expected).sort_values(['v_left', 'v_right'])
         pd.testing.assert_frame_equal(expected, result)


### PR DESCRIPTION
This PR improves the efficiency of the spatial join algorithm for the case where the left frame is a `DaskGeoDataFrame` and the right frame is a `GeoDataFrame`.

Now, we iterate over the partitions of the left frame and use the partition bounding box to extract the candidate rows from the right frame (using the right frame's spatial index). If no rows are selected while performing an `inner` join, the partition is skipped altogether.

722ca87  also adds a fix to make sure that that pyarrow parquet parts are sorted properly when loading a parquet file.