### PR TITLE
categorical fix and retry filesystem operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 0.3.1
+=============
+
+### Fixed
+ - Restored `categories` argument to `read_parquet_dask` function
+ - Retry filesystem operations in `pack_partitions_to_parquet` using exponential backoff
+
 Version 0.3.0
 =============
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ install_requires = [
       'pyarrow>=0.15',
       'param',
       'fsspec',
+      'retrying',
 ]
 
 setup(name='spatialpandas',

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -224,7 +224,11 @@ class DaskGeoDataFrame(dd.DataFrame):
         filesystem = validate_coerce_filesystem(path, filesystem)
 
         # Decorator for operations that should be retried
-        retryit = retry(wait_exponential_multiplier=1000, wait_exponential_max=10000)
+        retryit = retry(
+            wait_exponential_multiplier=1000,
+            wait_exponential_max=10000,
+            stop_max_attempt_number=10
+        )
 
         @retryit
         def rm_retry(file_path):

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -318,7 +318,8 @@ class DaskGeoDataFrame(dd.DataFrame):
             # single GeoDataFrame
             if not filesystem.ls(parts_tmp_path):
                 # Empty partition
-                filesystem.rm(parts_tmp_path, recursive=True)
+                if filesystem.exists(parts_tmp_path):
+                    filesystem.rm(parts_tmp_path, recursive=True)
                 return None
             else:
                 part_df = read_parquet(parts_tmp_path, filesystem=filesystem)

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -206,6 +206,11 @@ def read_parquet_dask(
     # Expand glob
     if len(path) == 1 and ('*' in path[0] or '?' in path[0] or '[' in path[0]):
         path = filesystem.glob(path[0])
+        if filesystem.protocol != "file":
+            # Add back prefix (e.g. s3://)
+            path = [
+                "{proto}://{p}".format(proto=filesystem.protocol, p=p) for p in path
+            ]
 
     # Perform read parquet
     result = _perform_read_parquet_dask(


### PR DESCRIPTION
A few fixes for 0.3.1:

 - Add categories kwarg to `read_parquet_dask` to work around dask/dask#5677
 - Use the `retrying` library to retry filesystem operations in `pack_partitions_to_parquet` 
 - Fix for loading multiple parquet files with a glob string while using a filesystem with protocol.

