### PR TITLE
Add pyarrow 1.0 and pandas 1.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION pandas dask numba numpy "pyarrow<1" pytest hypothesis scipy shapely geopandas param hilbertcurve
+  - conda create -q -n test-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION pandas dask numba numpy pyarrow pytest hypothesis scipy shapely geopandas param hilbertcurve
   - conda activate test-environment
   - python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
       'dask>=2.0',
       'numba',
       'numpy',
-      'pyarrow>=0.15,<1',
+      'pyarrow>=0.15',
       'param',
       'fsspec',
       'retrying',

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -68,7 +68,14 @@ class GeometryDtype(ExtensionDtype):
     @classmethod
     def construct_from_string(cls, string):
         # lowercase string
-        string = string.lower()
+        try:
+            string = string.lower()
+            if not isinstance(string, str):
+                raise AttributeError
+        except AttributeError:
+            raise TypeError(
+                "'construct_from_string' expects a string, got {typ}".format(
+                    typ=type(string)))
 
         msg = "Cannot construct a '%s' from '{}'" % cls.__name__
         if string.startswith(cls._geometry_name.lower()):
@@ -465,6 +472,8 @@ Cannot check equality of {typ} of length {a_len} with:
     def _from_sequence(cls, scalars, dtype=None, copy=None):
         if isinstance(scalars, cls):
             return scalars
+        elif isinstance(scalars, Geometry):
+            scalars = [scalars]
 
         return cls([
             None if np.isscalar(v) and np.isnan(v) else v for v in scalars

--- a/tests/test_fixedextensionarray.py
+++ b/tests/test_fixedextensionarray.py
@@ -128,6 +128,18 @@ def use_numpy(request):
     return request.param
 
 
+@pytest.fixture(params=[None, lambda x: x])
+def sort_by_key(request):
+    """
+    copied from pandas.conftest. Not sure why importing this module isn't enough
+    to register fixture with pytest
+
+    Simple fixture for testing keys in sorting methods.
+    Tests None (no key) and the identity key.
+    """
+    return request.param
+
+
 # Subclass BaseDtypeTests to run pandas-provided extension array test suite
 class TestGeometryConstructors(eb.BaseConstructorsTests):
     pass
@@ -193,6 +205,18 @@ class TestGeometryMethods(eb.BaseMethodsTests):
         reason="Searchsorted seems not implemented for custom extension arrays"
     )
     def test_searchsorted(self):
+        pass
+
+    @pytest.mark.skip(
+        reason="__setitem__ not supported"
+    )
+    def test_shift_0_periods(self, data):
+        pass
+
+    @pytest.mark.skip(
+        reason="value_counts not yet supported"
+    )
+    def test_value_counts_with_normalize(self, data):
         pass
 
 

--- a/tests/test_listextensionarray.py
+++ b/tests/test_listextensionarray.py
@@ -128,6 +128,18 @@ def use_numpy(request):
     return request.param
 
 
+@pytest.fixture(params=[None, lambda x: x])
+def sort_by_key(request):
+    """
+    copied from pandas.conftest. Not sure why importing this module isn't enough
+    to register fixture with pytest
+
+    Simple fixture for testing keys in sorting methods.
+    Tests None (no key) and the identity key.
+    """
+    return request.param
+
+
 # Subclass BaseDtypeTests to run pandas-provided extension array test suite
 class TestGeometryConstructors(eb.BaseConstructorsTests):
     pass
@@ -195,6 +207,17 @@ class TestGeometryMethods(eb.BaseMethodsTests):
     def test_searchsorted(self):
         pass
 
+    @pytest.mark.skip(
+        reason="__setitem__ not supported"
+    )
+    def test_shift_0_periods(self, data):
+        pass
+
+    @pytest.mark.skip(
+        reason="value_counts not yet supported"
+    )
+    def test_value_counts_with_normalize(self, data):
+        pass
 
 class TestGeometryPrinting(eb.BasePrintingTests):
     pass

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -42,7 +42,7 @@ def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path):
     to_parquet(df, path)
     df_read = read_parquet(str(path), columns=['point', 'multipoint', 'multiline', 'a'])
     assert isinstance(df_read, GeoDataFrame)
-    assert all(df == df_read)
+    pd.testing.assert_frame_equal(df, df_read)
     assert df_read.index.name == df.index.name
 
 
@@ -67,7 +67,7 @@ def test_parquet_columns(gp_point, gp_multipoint, gp_multiline, tmp_path):
     columns = ['a', 'multiline']
     df_read = read_parquet(str(path), columns=columns)
     assert isinstance(df_read, GeoDataFrame)
-    assert all(df[columns] == df_read)
+    pd.testing.assert_frame_equal(df[columns], df_read)
 
 
 @given(


### PR DESCRIPTION
This PR adds support for `pyarrow` 1.0, maintaining compatibility with the currently working pre-1.0 versions of `pyarrow`.

It also removes the upper pyarrow constraint bounds from the setup.py metadata and the CI test environment.

Closes https://github.com/holoviz/spatialpandas/issues/43