### PR TITLE
Allow using cx indexer without spatial index

### DIFF
--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -575,11 +575,21 @@ class _DaskCoordinateIndexer(_BaseCoordinateIndexer):
             # No partitions intersect with query region, return empty result
             return dd.from_pandas(self._obj._meta, npartitions=1)
 
-        def cx_fn(df, x0, x1, y0, y1):
+        @delayed
+        def cx_fn(df):
             return df.cx[x0:x1, y0:y1]
 
         ddf = self._obj.partitions[all_partition_inds]
-        return ddf.map_partitions(cx_fn, meta=ddf._meta, x0=x0, x1=x1, y0=y0, y1=y1)
+        delayed_dfs = []
+        for partition_ind, delayed_df in zip(all_partition_inds, ddf.to_delayed()):
+            if partition_ind in overlaps_inds:
+                delayed_dfs.append(
+                    cx_fn(delayed_df)
+                )
+            else:
+                delayed_dfs.append(delayed_df)
+
+        return dd.from_delayed(delayed_dfs, meta=ddf._meta, divisions=ddf.divisions)
 
 
 class _DaskPartitionCoordinateIndexer(_BaseCoordinateIndexer):

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -76,6 +76,12 @@ class DaskGeoSeries(dd.Series):
     def cx_partitions(self):
         return _DaskPartitionCoordinateIndexer(self, self.partition_sindex)
 
+    def build_sindex(self):
+        def build_sindex(series):
+            series.build_sindex()
+            return series
+        return self.map_partitions(build_sindex, meta=self._meta)
+
     def intersects_bounds(self, bounds):
         return self.map_partitions(lambda s: s.intersects_bounds(bounds))
 
@@ -514,6 +520,12 @@ class DaskGeoDataFrame(dd.DataFrame):
         if new_series.name in self._partition_sindex:
             new_series._partition_sindex = self._partition_sindex[new_series.name]
         return new_series
+
+    def build_sindex(self):
+        def build_sindex(df):
+            df.build_sindex()
+            return df
+        return self.map_partitions(build_sindex, meta=self._meta)
 
     def persist(self, **kwargs):
         return self._propagate_props_to_dataframe(

--- a/spatialpandas/geodataframe.py
+++ b/spatialpandas/geodataframe.py
@@ -112,6 +112,9 @@ class GeoDataFrame(pd.DataFrame):
             self.geometry.array, parent=self
         )
 
+    def build_sindex(self):
+        self.geometry.build_sindex()
+
     def _ensure_type(self, obj):
         # Override because a GeoDataFrame operation may result in a regular DataFrame,
         # and that's ok

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -542,8 +542,6 @@ Cannot check equality of {typ} of length {a_len} with:
     def build_sindex(self):
         if self._sindex is None:
             self._sindex = HilbertRtree(self.bounds)
-        else:
-            raise ValueError("Spatial index has already been built.")
 
     @property
     def cx(self):

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -675,7 +675,6 @@ class _CoordinateIndexer(_BaseCoordinateIndexer):
         overlaps_inds_mask = self._obj.intersects_bounds(
             (x0, y0, x1, y1), overlaps_inds
         )
-        print(overlaps_inds_mask)
         if covers_inds is not None:
             selected_inds = np.sort(
                 np.concatenate([covers_inds, overlaps_inds[overlaps_inds_mask]])

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -636,7 +636,10 @@ class _BaseCoordinateIndexer:
                 "intervals in continuous coordinate space, and a slice step has no "
                 "clear interpretation in this context."
             )
-        xmin, ymin, xmax, ymax = self._sindex.total_bounds
+        if self._sindex:
+            xmin, ymin, xmax, ymax = self._sindex.total_bounds
+        else:
+            xmin, ymin, xmax, ymax = self._obj.total_bounds
         x0, y0, x1, y1 = (
             xs.start if xs.start is not None else xmin,
             ys.start if ys.start is not None else ymin,
@@ -652,7 +655,10 @@ class _BaseCoordinateIndexer:
 
     def __getitem__(self, key):
         x0, x1, y0, y1 = self._get_bounds(key)
-        covers_inds, overlaps_inds = self._sindex.covers_overlaps((x0, y0, x1, y1))
+        if self._sindex:
+            covers_inds, overlaps_inds = self._sindex.covers_overlaps((x0, y0, x1, y1))
+        else:
+            covers_inds, overlaps_inds = None, None
         return self._perform_get_item(covers_inds, overlaps_inds, x0, x1, y0, y1)
 
     def _perform_get_item(self, covers_inds, overlaps_inds, x0, x1, y0, y1):
@@ -661,7 +667,7 @@ class _BaseCoordinateIndexer:
 
 class _CoordinateIndexer(_BaseCoordinateIndexer):
     def __init__(self, obj, parent=None):
-        super().__init__(obj.sindex)
+        super().__init__(obj._sindex)
         self._obj = obj
         self._parent = parent
 
@@ -669,16 +675,24 @@ class _CoordinateIndexer(_BaseCoordinateIndexer):
         overlaps_inds_mask = self._obj.intersects_bounds(
             (x0, y0, x1, y1), overlaps_inds
         )
-        selected_inds = np.sort(
-            np.concatenate([covers_inds, overlaps_inds[overlaps_inds_mask]])
-        )
-        if self._parent is not None:
-            if len(self._parent) > 0:
-                return self._parent.iloc[selected_inds]
-            else:
-                return self._parent
-        else:
+        print(overlaps_inds_mask)
+        if covers_inds is not None:
+            selected_inds = np.sort(
+                np.concatenate([covers_inds, overlaps_inds[overlaps_inds_mask]])
+            )
+            if self._parent is not None:
+                if len(self._parent) > 0:
+                    return self._parent.iloc[selected_inds]
+                else:
+                    return self._parent
             return self._obj[selected_inds]
+        else:
+            if self._parent is not None:
+                if len(self._parent) > 0:
+                    return self._parent[overlaps_inds_mask]
+                else:
+                    return self._parent
+            return self._obj[overlaps_inds_mask]
 
 
 @ngjit

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -536,8 +536,14 @@ Cannot check equality of {typ} of length {a_len} with:
     @property
     def sindex(self):
         if self._sindex is None:
-            self._sindex = HilbertRtree(self.bounds)
+            self.build_sindex()
         return self._sindex
+
+    def build_sindex(self):
+        if self._sindex is None:
+            self._sindex = HilbertRtree(self.bounds)
+        else:
+            raise ValueError("Spatial index has already been built.")
 
     @property
     def cx(self):

--- a/spatialpandas/geoseries.py
+++ b/spatialpandas/geoseries.py
@@ -76,6 +76,9 @@ class GeoSeries(pd.Series):
         from .geometry.base import _CoordinateIndexer
         return _CoordinateIndexer(self.array, parent=self)
 
+    def build_sindex(self):
+        self.array.build_sindex()
+
     def intersects_bounds(self, bounds):
         return pd.Series(
             self.array.intersects_bounds(bounds), index=self.index

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -179,7 +179,7 @@ def to_parquet_dask(
 
 def read_parquet_dask(
         path, columns=None, filesystem=None, load_divisions=False,
-        geometry=None, bounds=None, categories=None,
+        geometry=None, bounds=None, categories=None, build_sindex=False
 ):
     """
     Read spatialpandas parquet dataset(s) as DaskGeoDataFrame. Datasets are assumed to
@@ -207,6 +207,8 @@ def read_parquet_dask(
             If a list, assumes up to 2**16-1 labels; if a dict, specify the number
             of labels expected; if None, will load categories automatically for
             data written by dask/fastparquet, not otherwise.
+        build_sindex : boolean
+            Whether to build partition level spatial indexes to speed up indexing.
     Returns:
     DaskGeoDataFrame
     """
@@ -232,6 +234,9 @@ def read_parquet_dask(
         load_divisions=load_divisions, geometry=geometry, bounds=bounds,
         categories=categories
     )
+
+    if build_sindex:
+        result = result.build_sindex()
 
     return result
 


### PR DESCRIPTION
The problem with using `cx` on a DaskGeoDataFrame was that it would use `cx` on each partition which in turn would spatially index that partition because it was using the `sindex` attribute. It seems as though these spatial indexing wouldn't persist either so every time you did some indexing it would create a completely new `sindex` slowing down the indexing massively. I now only use the sindex if it already exists. I would like there to be a more explicit API on GeometryArrays, GeoSeries, GeoDataFrames, DaskGeoSeries and DaskGeoDataFrame that says "create an spatial index" rather than using the implicit behavior of creating a spatial index when `sindex` is accessed. 