### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit ecosystem=pip package_build $PKG_TEST_PYTHON --test-group=unit
+          doit package_build $PKG_TEST_PYTHON --test-group=unit
       - name: pip upload
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit package_build $PKG_TEST_PYTHON --test-group=unit
+          doit ecosystem=pip package_build $PKG_TEST_PYTHON --no-pkg-test
       - name: pip upload
         run: |
           eval "$(conda shell.bash hook)"


### PR DESCRIPTION
Temporarily disable pip package build tests (the tests are still run but not on the package itself).