### PR TITLE
Update docstrings, CHANGELOG and pass storage_options to read_parquet_dask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Version 0.4.3
+
+Date: 2021-08-05
+
+This release primarily expands the optional arguments that can be passed to `to_parquet_dask`/`read_parquet_dask` ensuring that `storage_options` is successfully passed where needed. 
+
+Bug fixes:
+- Reimplements `validate_coerce_filesystem`. Old implementation which would create a new filesystem object (even though one was already passed in), resulting in `key`/`secret` attributes being cleared.  
+
+
 ## Version 0.4.2
 
 This release primarily achieves compatibility with recent releases of Pandas. Many thanks to @Hoxbro for contributing the fixes and @philippjfr for ongoing maintenance of the project.

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -228,6 +228,8 @@ class DaskGeoDataFrame(dd.DataFrame):
 
                 These directories are deleted as soon as possible during the execution
                 of the function.
+            storage_options: Key/value pairs to be passed on to the file-system backend, if any.
+            engine_kwargs: pyarrow.parquet engine-related keyword arguments.
         Returns:
             DaskGeoDataFrame backed by newly written parquet dataset
         """

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -228,7 +228,8 @@ class DaskGeoDataFrame(dd.DataFrame):
 
                 These directories are deleted as soon as possible during the execution
                 of the function.
-            storage_options: Key/value pairs to be passed on to the file-system backend, if any.
+            storage_options: Key/value pairs to be passed on to the file-system backend,
+                if any.
             engine_kwargs: pyarrow.parquet engine-related keyword arguments.
         Returns:
             DaskGeoDataFrame backed by newly written parquet dataset

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -177,7 +177,8 @@ def to_parquet_dask(
                     path,
                     columns=[series_name],
                     filesystem=filesystem,
-                    load_divisions=False
+                    load_divisions=False,
+                    storage_options=storage_options,
                 )[series_name]
             partition_bounds[series_name] = series.partition_bounds.to_dict()
 
@@ -232,6 +233,8 @@ def read_parquet_dask(
             data written by dask/fastparquet, not otherwise.
         build_sindex : boolean
             Whether to build partition level spatial indexes to speed up indexing.
+        storage_options: Key/value pairs to be passed on to the file-system backend, if any.
+        engine_kwargs: pyarrow.parquet engine-related keyword arguments.
     Returns:
     DaskGeoDataFrame
     """

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -233,7 +233,8 @@ def read_parquet_dask(
             data written by dask/fastparquet, not otherwise.
         build_sindex : boolean
             Whether to build partition level spatial indexes to speed up indexing.
-        storage_options: Key/value pairs to be passed on to the file-system backend, if any.
+        storage_options: Key/value pairs to be passed on to the file-system backend,
+            if any.
         engine_kwargs: pyarrow.parquet engine-related keyword arguments.
     Returns:
     DaskGeoDataFrame

--- a/spatialpandas/io/utils.py
+++ b/spatialpandas/io/utils.py
@@ -11,7 +11,8 @@ def validate_coerce_filesystem(path, filesystem=None):
         path: Path as a string
         filesystem: Optional fsspec filesystem object to use to open the file. If not
             provided, filesystem type is inferred from path
-        storage_options: Key/value pairs to be passed on to the file-system backend, if any.
+        storage_options: Key/value pairs to be passed on to the file-system backend,
+            if any.
 
     Returns:
         fsspec file system

--- a/spatialpandas/io/utils.py
+++ b/spatialpandas/io/utils.py
@@ -11,6 +11,7 @@ def validate_coerce_filesystem(path, filesystem=None):
         path: Path as a string
         filesystem: Optional fsspec filesystem object to use to open the file. If not
             provided, filesystem type is inferred from path
+        storage_options: Key/value pairs to be passed on to the file-system backend, if any.
 
     Returns:
         fsspec file system


### PR DESCRIPTION
Questions:
- Do we want to include docstrings for `_retry_args` (`pack_partitions_to_parquet`)?
- Do we want to pass `storage_options` to `pandas.to_parquet` call?
    - [Available as a parameter in pandas > 1.2](https://github.com/pandas-dev/pandas/blob/eccfe9097ecf5d0d5fd5437290e956757d27933e/pandas/core/frame.py#L2631)
    - See `write_partition` (`pack_partitions_to_parquet`)