### PR TITLE
CI: make the workflows more consistent with the other HoloViz packages 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,8 @@ on:
         - dryrun
         required: true
         default: dryrun
+  schedule:
+    - cron: '0 01 * * SUN'
 
 jobs:
   conda_build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,16 @@ on:
     - 'v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+  # Dry-run only
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Build mode'
+        type: choice
+        options:
+        - dryrun
+        required: true
+        default: dryrun
 
 jobs:
   conda_build:
@@ -42,10 +52,10 @@ jobs:
       - name: conda build
         run: doit package_build $CHANS_DEV $PKG_TEST_PYTHON --test-group=all
       - name: conda dev upload
-        if: (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc'))
+        if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev
       - name: conda main upload
-        if: (!(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+        if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev --label=main
   pip_build:
     name: Build PyPI Packages
@@ -89,6 +99,7 @@ jobs:
           conda activate test-environment
           doit ecosystem=pip package_build $PKG_TEST_PYTHON --no-pkg-test
       - name: pip upload
+        if: github.event_name == 'push'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
     - '*'
+  workflow_dispatch:
 
 jobs:
   test_suite:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: tests
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,4 @@
-# things not included
-# language
-# notifications - no email notifications set up
-
-name: pytest
+name: tests
 on:
   pull_request:
     branches:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ on:
     branches:
     - '*'
   workflow_dispatch:
+  schedule:
+    - cron: '0 01 * * SUN'
 
 jobs:
   test_suite:


### PR DESCRIPTION
@ianthomas23 I hope this is not stepping on your toes, I noticed that the [status dashboard](https://status.holoviz.org/) wasn't reporting the test state as the workflow was not running on master. I took the opportunity to make a few other changes so that the repo is a little more inline with the other repos, by:

- Allowing the workflows to be launched manually, only in dry-run mode for the packages build workflow
- Having the workflows run on Sundays
