### PR TITLE
Changelog and package build improvements for v0.4.4 release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,10 +27,8 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      CHANS_DEV: "-c pyviz/label/dev  -c conda-forge"
       PKG_TEST_PYTHON: "--test-python=py37"
       PYTHON_VERSION: "3.7"
-      CHANS: "-c pyviz"
       CONDA_UPLOAD_TOKEN: ${{ secrets.CONDA_UPLOAD_TOKEN }}
     steps:
       - uses: actions/checkout@v2
@@ -42,17 +40,21 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.7
+          python-version: $PYTHON_VERSION
       - name: Set output
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: conda setup
         run: |
           conda config --set always_yes True
-          conda install -c pyviz "pyctdev>=0.5"
+          conda install -c pyviz pyctdev
           doit ecosystem_setup
+          conda create -n test-environment python=$PYTHON_VERSION
+          conda activate test-environment
+          conda config --env --append channels pyviz/label/dev --append channels conda-forge
+          conda install pyctdev
       - name: conda build
-        run: doit package_build $CHANS_DEV $PKG_TEST_PYTHON --test-group=all
+        run: doit package_build $PKG_TEST_PYTHON --test-group=all
       - name: conda dev upload
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: doit package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev
@@ -66,10 +68,8 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      CHANS_DEV: "-c pyviz/label/dev -c conda-forge"
       PKG_TEST_PYTHON: "--test-python=py37"
       PYTHON_VERSION: "3.7"
-      CHANS: "-c pyviz"
       PPU: ${{ secrets.PPU }}
       PPP: ${{ secrets.PPP }}
       PYPI: "https://upload.pypi.org/legacy/"
@@ -83,17 +83,21 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
+          python-version: $PYTHON_VERSION
       - name: conda setup
         run: |
           conda config --set always_yes True
-          conda install -c pyviz "pyctdev>=0.5"
+          conda install -c pyviz pyctdev
           doit ecosystem_setup
-          doit env_create $CHANS_DEV --python=$PYTHON_VERSION
+          conda create -n test-environment python=$PYTHON_VERSION
+          conda activate test-environment
+          conda config --env --append channels pyviz/label/dev --append channels conda-forge
+          conda install pyctdev
       - name: env setup
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install $CHANS_DEV -o tests
+          doit develop_install -o tests
           doit pip_on_conda
       - name: pip build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Version 0.4.4
+
+Date: 2022-07-29
+
+This release achieves compatibility with recent versions of Dask, Pandas, PyArrow and Shapely.
+
+Enhancements:
+
+- Avoid inappropriate geometry tests ([#90](https://github.com/holoviz/spatialpandas/pull/90))
+
+Compatibility:
+
+- Fix Shapely deprecation warnings ([#85](https://github.com/holoviz/spatialpandas/pull/85))
+- Pandas extension array fixes ([#88](https://github.com/holoviz/spatialpandas/pull/88))
+- PyArrow and Dask parquet issues ([#92](https://github.com/holoviz/spatialpandas/pull/92))
+
 ## Version 0.4.3
 
 Date: 2021-08-07


### PR DESCRIPTION
This PR adds CHANGELOG entries for the v0.4.4 release, and updates the package building workflow in line with the testing workflow.

The intention is to release v0.4.4 today as it has been almost a year since the previous release, then we can address the remaining issues and pull requests as part of a regular ongoing maintenance and release strategy.