### PR TITLE
Skip test_fillna_frame and test_fillna_series extension array tests

### DIFF
--- a/spatialpandas/tests/test_fixedextensionarray.py
+++ b/spatialpandas/tests/test_fixedextensionarray.py
@@ -242,7 +242,13 @@ class TestGeometryPrinting(eb.BasePrintingTests):
 
 
 class TestGeometryMissing(eb.BaseMissingTests):
-    pass
+    @pytest.mark.skip(reason="__setitem__ not supported")
+    def test_fillna_frame(self):
+        pass
+
+    @pytest.mark.skip(reason="__setitem__ not supported")
+    def test_fillna_series(self):
+        pass
 
 
 class TestGeometryReshaping(eb.BaseReshapingTests):

--- a/spatialpandas/tests/test_listextensionarray.py
+++ b/spatialpandas/tests/test_listextensionarray.py
@@ -241,7 +241,14 @@ class TestGeometryPrinting(eb.BasePrintingTests):
 
 
 class TestGeometryMissing(eb.BaseMissingTests):
-    pass
+    @pytest.mark.skip(reason="__setitem__ not supported")
+    def test_fillna_frame(self):
+        pass
+
+    @pytest.mark.skip(reason="__setitem__ not supported")
+    def test_fillna_series(self):
+        pass
+
 
 
 class TestGeometryReshaping(eb.BaseReshapingTests):


### PR DESCRIPTION
Current failures in CI:
```
FAILED spatialpandas/tests/test_fixedextensionarray.py::TestGeometryMissing::test_fillna_series
FAILED spatialpandas/tests/test_fixedextensionarray.py::TestGeometryMissing::test_fillna_frame
FAILED spatialpandas/tests/test_listextensionarray.py::TestGeometryMissing::test_fillna_series
FAILED spatialpandas/tests/test_listextensionarray.py::TestGeometryMissing::test_fillna_frame
```
The original errors are:
```
NotImplementedError: <class 'spatialpandas.geometry.line.LineArray'> does not implement __setitem__.
```
So, as usual with new pandas ExtensionArray tests we skip them as we do not support this specific functionality.