### PR TITLE
Don't use dtype=object when converting arrays to pass to shapely 2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: [3.7, 3.8, 3.9, '3.10']
-    timeout-minutes: 120
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: [3.7, 3.8, 3.9, '3.10']
-    timeout-minutes: 60
+    timeout-minutes: 120
     defaults:
       run:
         shell: bash -l {0}

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         'pytest',
         'rfc3986',
         'scipy',
-        'shapely >=2.0',
+        'shapely',
         'twine',
     ],
     'examples': [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         'pytest',
         'rfc3986',
         'scipy',
-        'shapely',
+        'shapely >=2.0',
         'twine',
     ],
     'examples': [

--- a/spatialpandas/geometry/multipolygon.py
+++ b/spatialpandas/geometry/multipolygon.py
@@ -59,7 +59,7 @@ Received invalid value of type {typ}. Must be an instance of Polygon or MultiPol
             shapely MultiPolygon shape
         """
         import shapely.geometry as sg
-        polygon_arrays = np.asarray(self.data.as_py(), dtype=object)
+        polygon_arrays = self.data.as_py()
 
         polygons = []
         for polygon_array in polygon_arrays:

--- a/spatialpandas/geometry/polygon.py
+++ b/spatialpandas/geometry/polygon.py
@@ -61,7 +61,7 @@ Received invalid value of type {typ}. Must be an instance of Polygon
         """
         import shapely.geometry as sg
         ring_arrays = [np.asarray(line_coords).reshape(len(line_coords) // 2, 2)
-                       for line_coords in np.asarray(self.data.as_py(), dtype=object)]
+                       for line_coords in self.data.as_py()]
         rings = [sg.LinearRing(ring_array) for ring_array in ring_arrays]
         return sg.Polygon(shell=rings[0], holes=rings[1:])
 


### PR DESCRIPTION
Potential fix for #102. The code change is to avoid using `numpy` arrays with `dtype=object` as `shapely` 2.0 quite rightly is not expecting this.