### PR TITLE
Support numpy 1.24 ragged array conversion

### DIFF
--- a/spatialpandas/geometry/basefixed.py
+++ b/spatialpandas/geometry/basefixed.py
@@ -5,6 +5,7 @@ import pyarrow as pa
 
 from ..geometry.base import Geometry, GeometryArray, GeometryDtype
 from ..geometry.baselist import _lexographic_lt
+from ..utils import _asarray_maybe_ragged
 from ._algorithms.bounds import (bounds_interleaved, total_bounds_interleaved,
                                  total_bounds_interleaved_1d)
 
@@ -108,7 +109,7 @@ class GeometryFixedArray(GeometryArray):
             else:
                 invalid_array()
         else:
-            array = np.asarray(array)
+            array = _asarray_maybe_ragged(array)
             if array.dtype.kind == 'O':
                 if array.ndim != 1:
                     invalid_array()

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -405,7 +405,6 @@ def _perform_read_parquet_dask(
         filesystem=filesystem,
         engine='pyarrow',
         categories=categories,
-        gather_statistics=False,
         storage_options=storage_options,
         **engine_kwargs,
     )._meta


### PR DESCRIPTION
Fixes #106 and #49.

Implicit conversion of a ragged array (sequence of numpy arrays with incompatible shapes) in numpy 1.24 raises a `ValueError` rather than a warning.  This is a solution to the problem inspired by https://github.com/holoviz/geoviews/pull/608 (thanks @Hoxbro). It is slightly more complicated than that GeoViews fix because we cannot test with numpy 1.24 until numba supports it, so here I am converting the warning that occurs for numpy < 1.24 into an error so that it is handled in the same way and in the same code path as the numpy >= 1.24 fix.

This PR also fixes the following warning:
```
FutureWarning: ``gather_statistics`` is deprecated and will be removed in a future release. Please use ``calculate_divisions`` instead.
```