### PR TITLE
Remove all use of parquet's validate_schema

### DIFF
--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -146,16 +146,21 @@ def read_parquet(
     engine_kwargs = engine_kwargs or {}
     filesystem = validate_coerce_filesystem(path, filesystem, storage_options)
 
-    # Load pandas parquet metadata
-    metadata = _load_parquet_pandas_metadata(
+    # Load using pyarrow to handle parquet files and directories across filesystems
+    dataset = pq.ParquetDataset(
         path,
         filesystem=filesystem,
-        storage_options=storage_options,
-        engine_kwargs=engine_kwargs,
+        #validate_schema=False,
+        use_legacy_dataset=False,
+        **engine_kwargs,
+        **kwargs,
     )
+
+    metadata = dataset.schema.pandas_metadata
 
     # If columns specified, prepend index columns to it
     if columns is not None:
+        all_columns = set(column['name'] for column in metadata.get('columns', []))
         index_col_metadata = metadata.get('index_columns', [])
         extra_index_columns = []
         for idx_metadata in index_col_metadata:
@@ -165,20 +170,12 @@ def read_parquet(
                 name = idx_metadata.get('name', None)
             else:
                 name = None
-
-            if name is not None and name not in columns:
+            if name is not None and name not in columns and name in all_columns:
                 extra_index_columns.append(name)
 
         columns = extra_index_columns + list(columns)
 
-    # Load using pyarrow to handle parquet files and directories across filesystems
-    df = pq.ParquetDataset(
-        path,
-        filesystem=filesystem,
-        validate_schema=False,
-        **engine_kwargs,
-        **kwargs,
-    ).read(columns=columns).to_pandas()
+    df = dataset.read(columns=columns).to_pandas()
 
     # Import geometry columns, not needed for pyarrow >= 0.16
     geom_cols = _get_geometry_columns(metadata)


### PR DESCRIPTION
Fixes #109.

Test suite passes using latest `pyarrow == 11.0.0`.

Fix isn't quite as simple as removing the final use of `validate_schema` keyword argument. It was also necessary when identifying which columns to read from the parquet file to check which are classified as columns rather than indexes. I have also simplified the code a bit as it no longer needs a separate load of the `metadata` before creating the `ParquetDataset`.

This fix works for `pyarrow >= 5` (July 2021). I will try out another PR to support earlier `pyarrow` but the changes will be wider-ranging as there are a number of places in the code that do not currently support `pyarrow < 5` before this PR is considered.