### PR TITLE
Fix read parquet from remote filesystems

### DIFF
--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -326,11 +326,11 @@ def _perform_read_parquet_dask(
 
     datasets = [
         pq.ParquetDataset(
-            paths,
+            path,
             filesystem=filesystem,
             **basic_kwargs,
             **engine_kwargs,
-        )
+        ) for path in paths
     ]
 
     # Create delayed partition for each piece


### PR DESCRIPTION
I noticed some of the path handling for parquet files would munge paths for remote filesystems and confirmed after testing with s3.  This PR fixes that issue.