### PR TITLE
Set python version in Build PyPI Packages github action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
         run: git fetch --prune --tags --unshallow -f
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $PYTHON_VERSION
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"


### PR DESCRIPTION
There is a warning in the Build PyPI Packages github action:

```
The `python-version` input is not set. The version of Python currently in `PATH` will be used.
```

This PR fixes it.