### PR TITLE
Construct `PolygonArray` or `MultiPolygonArray` from Exterior Coordinates 

### DIFF
--- a/examples/Polygon-Array-Construction-From-Exterior.ipynb
+++ b/examples/Polygon-Array-Construction-From-Exterior.ipynb
@@ -1,0 +1,505 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Constructing PolygonArray and MultiPolygonArray From Exterior Coordinates"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "2cd5cfcaaec15924"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from shapely import Polygon, MultiPolygon\n",
+    "from spatialpandas.geometry import PolygonArray, MultiPolygonArray"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.096454900Z",
+     "start_time": "2023-11-08T07:57:33.981231200Z"
+    }
+   },
+   "id": "3abb9112543deeed"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.102489200Z",
+     "start_time": "2023-11-08T07:57:35.098406800Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "polygon_shell = np.array([[89.97223, -58.302593],\n",
+    "                          [89.98285, -58.29493],\n",
+    "                          [89.97226, -58.27778],\n",
+    "                          [89.95511, -58.27485],\n",
+    "                          [89.92737, -58.28543],\n",
+    "                          [89.93793, -58.30258],\n",
+    "                          [89.97223, -58.302593]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<POLYGON ((90 -58.3, 90 -58.3, 90 -58.3, 90 -58.3, 89.9 -58.3, 89.9 -58.3, 9...>",
+      "image/svg+xml": "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"89.9251508 -58.3048122 0.059918400000000815 0.032181399999998916\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,-116.577443)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.0011983680000000163\" opacity=\"0.6\" d=\"M 89.97223,-58.302593 L 89.98285,-58.29493 L 89.97226,-58.27778 L 89.95511,-58.27485 L 89.92737,-58.28543 L 89.93793,-58.30258 L 89.97223,-58.302593 z\" /></g></svg>"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p = Polygon(polygon_shell)\n",
+    "p"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.108079600Z",
+     "start_time": "2023-11-08T07:57:35.101489200Z"
+    }
+   },
+   "id": "e5a34738409c0a7a"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "array([[ 89.97223 , -58.302593],\n       [ 89.98285 , -58.29493 ],\n       [ 89.97226 , -58.27778 ],\n       [ 89.95511 , -58.27485 ],\n       [ 89.92737 , -58.28543 ],\n       [ 89.93793 , -58.30258 ],\n       [ 89.97223 , -58.302593]])"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exterior_coords = np.asarray(p.exterior.coords)\n",
+    "exterior_coords"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.113820200Z",
+     "start_time": "2023-11-08T07:57:35.106078300Z"
+    }
+   },
+   "id": "4853c29990a5ccb8"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## PolygonArray"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "3a482e38c725c99c"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Construction \n",
+    "\n",
+    "The following snippet shows the constructing of a `PolygonArray` containing three identical polygons"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "bbfc5046c274f351"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [],
+   "source": [
+    "p_arr_shapely = PolygonArray([p, p, p])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.119109100Z",
+     "start_time": "2023-11-08T07:57:35.111822300Z"
+    }
+   },
+   "id": "38d79bd38781891d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [],
+   "source": [
+    "p_arr_coords = PolygonArray.from_exterior_coords([exterior_coords, exterior_coords, exterior_coords])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.119109100Z",
+     "start_time": "2023-11-08T07:57:35.116969Z"
+    }
+   },
+   "id": "7d5b8c4d9de4e0e3"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can see the resulting results are equivalent."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "893cfe97b4165295"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.all(p_arr_shapely == p_arr_coords)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.124095500Z",
+     "start_time": "2023-11-08T07:57:35.119109100Z"
+    }
+   },
+   "id": "103c5ee78eca51cb"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Timing Comparison\n",
+    "\n",
+    "The main motivation for constructing from exterior coordinates is performance."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "5fc5c4c8f68b903e"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [],
+   "source": [
+    "N = 100000\n",
+    "p_list = [p for i in range(N)]\n",
+    "exterior_coord_list = [exterior_coords for i in range(N)]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:35.130307200Z",
+     "start_time": "2023-11-08T07:57:35.124095500Z"
+    }
+   },
+   "id": "95daa32f2210a7c0"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: total: 828 ms\n",
+      "Wall time: 2.82 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "p_arr_shapely = PolygonArray(p_list)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:37.956061400Z",
+     "start_time": "2023-11-08T07:57:35.130307200Z"
+    }
+   },
+   "id": "ecf90afd0150e470"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: total: 31.2 ms\n",
+      "Wall time: 135 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "p_arr_coords = PolygonArray.from_exterior_coords(exterior_coord_list)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:38.093193500Z",
+     "start_time": "2023-11-08T07:57:37.955059200Z"
+    }
+   },
+   "id": "b1b64408519020b6"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.all(p_arr_shapely == p_arr_coords)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:43.352097100Z",
+     "start_time": "2023-11-08T07:57:38.094191700Z"
+    }
+   },
+   "id": "2aa0a144619b90f9"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## MultiPolygonArray\n",
+    "\n",
+    "We can do the same with a MultiPolygonArray."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "2a8dcd0309ac1432"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [],
+   "source": [
+    "mp = MultiPolygon(polygons=[p, p])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:43.355143500Z",
+     "start_time": "2023-11-08T07:57:43.352097100Z"
+    }
+   },
+   "id": "92ae2e8dba3b6ba5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [],
+   "source": [
+    "mp_arr_shapely = MultiPolygonArray([mp])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:43.357439600Z",
+     "start_time": "2023-11-08T07:57:43.355143500Z"
+    }
+   },
+   "id": "2267ad66c94d426d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "outputs": [],
+   "source": [
+    "mp_arr_coords = MultiPolygonArray.from_exterior_coords([[exterior_coords, exterior_coords]])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:43.361949300Z",
+     "start_time": "2023-11-08T07:57:43.359440100Z"
+    }
+   },
+   "id": "aebf5e798b15be9c"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.all(mp_arr_shapely == mp_arr_coords)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:43.368265Z",
+     "start_time": "2023-11-08T07:57:43.362952600Z"
+    }
+   },
+   "id": "dcb54a675c1bd3af"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "outputs": [],
+   "source": [
+    "N = 100000\n",
+    "mp_list = [mp for i in range(N)]\n",
+    "exterior_coord_list = [[exterior_coords, exterior_coords] for i in range(N)]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:43.414588900Z",
+     "start_time": "2023-11-08T07:57:43.366266900Z"
+    }
+   },
+   "id": "a00c5625be68952a"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: total: 1.22 s\n",
+      "Wall time: 7.01 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "mp_arr_shapely = MultiPolygonArray(mp_list)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:50.426290900Z",
+     "start_time": "2023-11-08T07:57:43.415607200Z"
+    }
+   },
+   "id": "6513cbcbe996cc03"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: total: 15.6 ms\n",
+      "Wall time: 296 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "mp_arr_coords = MultiPolygonArray.from_exterior_coords(exterior_coord_list)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:50.723795100Z",
+     "start_time": "2023-11-08T07:57:50.425283300Z"
+    }
+   },
+   "id": "ccf9eeb58fcdf240"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.all(mp_arr_shapely == mp_arr_coords)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T07:57:58.301932Z",
+     "start_time": "2023-11-08T07:57:50.725135Z"
+    }
+   },
+   "id": "fd3dfe6db52368d"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -202,36 +202,6 @@ class GeometryArray(ExtensionArray):
             for shape in ga
         ])
 
-    @classmethod
-    def from_array(cls, arr):
-        """
-        Build a spatialpandas geometry array from a Numpy Array
-
-        Args:
-            arr: Numpy Array values to import
-
-        Returns:
-            spatialpandas geometry array with type of the calling class
-        """
-
-        # TODO: generalize this
-        return cls([cls._element_type._exterior_coords_to_coordinates(exterior) for exterior in arr])
-
-    @classmethod
-    def from_list(cls, element_list):
-        """
-        Build a spatialpandas geometry array from a Python List
-
-        Args:
-            element_list: List values to import
-
-        Returns:
-            spatialpandas geometry array with type of the calling class
-        """
-        # TODO: generalize this
-        return cls([cls._element_type._exterior_coords_to_coordinates(exterior) for exterior in element_list])
-
-
     def to_geopandas(self):
         """
         Convert a spatialpandas geometry array into a geopandas GeometryArray

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -13,7 +13,6 @@ from ..spatialindex import HilbertRtree
 from ..spatialindex.rtree import _distances_from_bounds
 from ..utils import ngjit
 
-
 def _unwrap_geometry(a, element_dtype):
     try:
         if np.isscalar(a) and np.isnan(a):
@@ -214,7 +213,8 @@ class GeometryArray(ExtensionArray):
         Returns:
             spatialpandas geometry array with type of the calling class
         """
-        print(cls._element_type)
+
+        # TODO: generalize this
         return cls([cls._element_type._exterior_coords_to_coordinates(exterior) for exterior in arr])
 
     @classmethod
@@ -228,7 +228,7 @@ class GeometryArray(ExtensionArray):
         Returns:
             spatialpandas geometry array with type of the calling class
         """
-
+        # TODO: generalize this
         return cls([cls._element_type._exterior_coords_to_coordinates(exterior) for exterior in element_list])
 
 

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -203,6 +203,13 @@ class GeometryArray(ExtensionArray):
             for shape in ga
         ])
 
+    @classmethod
+    def from_array(cls, exterior_arr):
+        """Docstring TODO"""
+
+        # currently only supports polygons with no holes
+        return cls([cls._element_type._exterior_array_to_coordinates(exterior) for exterior in exterior_arr])
+
     def to_geopandas(self):
         """
         Convert a spatialpandas geometry array into a geopandas GeometryArray

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -13,6 +13,7 @@ from ..spatialindex import HilbertRtree
 from ..spatialindex.rtree import _distances_from_bounds
 from ..utils import ngjit
 
+
 def _unwrap_geometry(a, element_dtype):
     try:
         if np.isscalar(a) and np.isnan(a):

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -204,11 +204,33 @@ class GeometryArray(ExtensionArray):
         ])
 
     @classmethod
-    def from_array(cls, exterior_arr):
-        """Docstring TODO"""
+    def from_array(cls, arr):
+        """
+        Build a spatialpandas geometry array from a Numpy Array
 
-        # currently only supports polygons with no holes
-        return cls([cls._element_type._exterior_array_to_coordinates(exterior) for exterior in exterior_arr])
+        Args:
+            arr: Numpy Array values to import
+
+        Returns:
+            spatialpandas geometry array with type of the calling class
+        """
+        print(cls._element_type)
+        return cls([cls._element_type._exterior_coords_to_coordinates(exterior) for exterior in arr])
+
+    @classmethod
+    def from_list(cls, element_list):
+        """
+        Build a spatialpandas geometry array from a Python List
+
+        Args:
+            element_list: List values to import
+
+        Returns:
+            spatialpandas geometry array with type of the calling class
+        """
+
+        return cls([cls._element_type._exterior_coords_to_coordinates(exterior) for exterior in element_list])
+
 
     def to_geopandas(self):
         """

--- a/spatialpandas/geometry/multipolygon.py
+++ b/spatialpandas/geometry/multipolygon.py
@@ -180,10 +180,12 @@ class MultiPolygonArray(GeometryListArray):
         """
         if isinstance(exterior_coords, (list, np.ndarray)):
             if isinstance(exterior_coords, np.ndarray):
-                warnings.warn("TODO: Warning for when a numpy array is passed, ")
+                warnings.warn(f"Constructing a MultiPolygonArray using a Numpy Array with a fixed shape {exterior_coords.shape}."
+                              f"Each MultiPolygon will contain exactly {exterior_coords.shape[0]} Polygons")
             mpa = [[[arr.ravel()] for arr in exterior] for exterior in exterior_coords]
         else:
-            raise ValueError("TODO")
+            raise TypeError(f"Construction of MultiPolygonArray only supports `list` or `np.ndarray` inputs. Received "
+                            f"{type(exterior_coords)}")
 
         return cls(mpa)
 

--- a/spatialpandas/geometry/multipolygon.py
+++ b/spatialpandas/geometry/multipolygon.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pyarrow as pa
+import warnings
 from dask.dataframe.extensions import make_array_nonempty
 from pandas.core.dtypes.dtypes import register_extension_dtype
 
@@ -157,6 +158,34 @@ class MultiPolygonArray(GeometryListArray):
             return mpa.oriented()
         else:
             return mpa
+
+    @classmethod
+    def from_exterior_coords(cls, exterior_coords):
+        """
+        Build a spatialpandas MultiPolygonArray from exterior coordinates represented as a Python List or Numpy Array.
+
+        Args:
+            exterior_coords: A Python List where each entry contains the exterior coordinates of one of more Polygons.
+                             Each of these entries may be either a Python List or Numpy Array containing the exterior
+                             coordinates for a series of Polygons. Each Polygon in a List may have an arbitrary number
+                             of vertices but require a fixed number for a Numpy array.
+
+        Returns:
+            MultiPolygonArray
+
+        Note:
+            When using a Numpy Array is passed in, it is assumed that each entry is unfired, meaning that
+            all resulting MultiPolygons will have the same number of Polygons.
+
+        """
+        if isinstance(exterior_coords, (list, np.ndarray)):
+            if isinstance(exterior_coords, np.ndarray):
+                warnings.warn("TODO: Warning for when a numpy array is passed, ")
+            mpa = [[[arr.ravel()] for arr in exterior] for exterior in exterior_coords]
+        else:
+            raise ValueError("TODO")
+
+        return cls(mpa)
 
     def oriented(self):
         missing = np.concatenate([self.isna(), [False]])

--- a/spatialpandas/geometry/multipolygon.py
+++ b/spatialpandas/geometry/multipolygon.py
@@ -177,11 +177,18 @@ class MultiPolygonArray(GeometryListArray):
             When using a Numpy Array is passed in, it is assumed that each entry is unfired, meaning that
             all resulting MultiPolygons will have the same number of Polygons.
 
+
+
         """
         if isinstance(exterior_coords, (list, np.ndarray)):
             if isinstance(exterior_coords, np.ndarray):
-                warnings.warn(f"Constructing a MultiPolygonArray using a Numpy Array with a fixed shape {exterior_coords.shape}."
-                              f"Each MultiPolygon will contain exactly {exterior_coords.shape[0]} Polygons")
+                if exterior_coords.ndim != 4:
+                    raise ValueError(f"Invalid number of dimensions encountered in `exterior_coords`. Expected 4 but "
+                                     f"received {exterior_coords.ndim}")
+                else:
+                    warnings.warn(f"Constructing a MultiPolygonArray using a Numpy Array with a fixed shape "
+                                  f"{exterior_coords.shape}."
+                                  f"Each MultiPolygon will contain exactly {exterior_coords.shape[0]} Polygons", stacklevel=2)
             mpa = [[[arr.ravel()] for arr in exterior] for exterior in exterior_coords]
         else:
             raise TypeError(f"Construction of MultiPolygonArray only supports `list` or `np.ndarray` inputs. Received "

--- a/spatialpandas/geometry/multipolygon.py
+++ b/spatialpandas/geometry/multipolygon.py
@@ -188,7 +188,7 @@ class MultiPolygonArray(GeometryListArray):
                 else:
                     warnings.warn(f"Constructing a MultiPolygonArray using a Numpy Array with a fixed shape "
                                   f"{exterior_coords.shape}."
-                                  f"Each MultiPolygon will contain exactly {exterior_coords.shape[0]} Polygons", stacklevel=2)
+                                  f"Each MultiPolygon will contain exactly {exterior_coords.shape[1]} Polygons", stacklevel=2)
             mpa = [[[arr.ravel()] for arr in exterior] for exterior in exterior_coords]
         else:
             raise TypeError(f"Construction of MultiPolygonArray only supports `list` or `np.ndarray` inputs. Received "

--- a/spatialpandas/geometry/polygon.py
+++ b/spatialpandas/geometry/polygon.py
@@ -170,7 +170,8 @@ class PolygonArray(GeometryListArray):
         if isinstance(exterior_coords, (list, np.ndarray)):
             polygons = [[exterior.ravel()] for exterior in exterior_coords]
         else:
-            raise ValueError("TODO")
+            raise TypeError(f"Construction of PolygonArray only supports `list` or `np.ndarray` inputs. Received "
+                            f"{type(exterior_coords)}")
         return cls(polygons)
 
     def oriented(self):

--- a/spatialpandas/geometry/polygon.py
+++ b/spatialpandas/geometry/polygon.py
@@ -170,7 +170,12 @@ class PolygonArray(GeometryListArray):
             less than the maximum number of vertices should have its exterior coordinates padded using the first entry.
 
         """
-        polygons = super().from_array(exterior_coords)
+        if isinstance(exterior_coords, list):
+            polygons = super().from_list(exterior_coords)
+        elif isinstance(exterior_coords, np.ndarray):
+            polygons = super().from_array(exterior_coords)
+        else:
+            raise ValueError("TODO")
         return polygons
 
     def oriented(self):

--- a/spatialpandas/geometry/polygon.py
+++ b/spatialpandas/geometry/polygon.py
@@ -54,9 +54,8 @@ Received invalid value of type {typ}. Must be an instance of Polygon
 """.format(typ=type(shape).__name__))
 
     @classmethod
-    def _exterior_array_to_coordinates(cls, arr):
+    def _exterior_coords_to_coordinates(cls, arr):
         return [arr.ravel()]
-
 
     def to_shapely(self):
         """
@@ -153,9 +152,26 @@ class PolygonArray(GeometryListArray):
         else:
             return polygons
 
+
     @classmethod
-    def from_exterior_array(cls, exterior_arr):
-        polygons = super().from_array(exterior_arr)
+    def from_exterior_coords(cls, exterior_coords):
+        """
+        Build a spatialpandas PolygonArray from exterior coordinates represented as a Python List or Numpy Array.
+
+        Args:
+            exterior_coords: A Python List or Numpy Array containing the exterior coordinates of a series of Polygons.
+                             Each Polygon in a List may have an arbitrary number of vertices but require a fixed
+                             number for a Numpy array.
+
+        Returns:
+            PolygonArray
+
+        Note:
+            When using a Numpy Array, each Polygon is assumed to have the same number of vertices. A polygon with
+            less than the maximum number of vertices should have its exterior coordinates padded using the first entry.
+
+        """
+        polygons = super().from_array(exterior_coords)
         return polygons
 
     def oriented(self):

--- a/spatialpandas/geometry/polygon.py
+++ b/spatialpandas/geometry/polygon.py
@@ -52,10 +52,6 @@ class Polygon(GeometryList):
 Received invalid value of type {typ}. Must be an instance of Polygon
 """.format(typ=type(shape).__name__))
 
-    @classmethod
-    def _exterior_coords_to_coordinates(cls, arr):
-        return [arr.ravel()]
-
     def to_shapely(self):
         """
         Convert to shapely shape
@@ -155,7 +151,8 @@ class PolygonArray(GeometryListArray):
     @classmethod
     def from_exterior_coords(cls, exterior_coords):
         """
-        Build a spatialpandas PolygonArray from exterior coordinates represented as a Python List or Numpy Array.
+        Build a spatialpandas MultiPolygonArray from exterior coordinates represented as a Python List or Numpy Array.
+
 
         Args:
             exterior_coords: A Python List or Numpy Array containing the exterior coordinates of a series of Polygons.
@@ -170,13 +167,11 @@ class PolygonArray(GeometryListArray):
             less than the maximum number of vertices should have its exterior coordinates padded using the first entry.
 
         """
-        if isinstance(exterior_coords, list):
-            polygons = super().from_list(exterior_coords)
-        elif isinstance(exterior_coords, np.ndarray):
-            polygons = super().from_array(exterior_coords)
+        if isinstance(exterior_coords, (list, np.ndarray)):
+            polygons = [[exterior.ravel()] for exterior in exterior_coords]
         else:
             raise ValueError("TODO")
-        return polygons
+        return cls(polygons)
 
     def oriented(self):
         missing = np.concatenate([self.isna(), [False]])

--- a/spatialpandas/tests/geometry/test_geometry.py
+++ b/spatialpandas/tests/geometry/test_geometry.py
@@ -17,6 +17,14 @@ from spatialpandas.geometry import (
 unit_square_cw = np.array([1, 1,  1, 2,  2, 2,  2, 1,  1, 1], dtype='float64')
 large_square_ccw = np.array([0, 0, 3, 0, 3, 3, 0, 3, 0, 0], dtype='float64')
 
+sample_polygon_exterior = np.array([[89.97223, -58.302593],
+                                    [89.98285, -58.29493],
+                                    [89.97226, -58.27778],
+                                    [89.95511, -58.27485],
+                                    [89.92737, -58.28543],
+                                    [89.93793, -58.30258],
+                                    [89.97223, -58.302593]])
+
 
 def test_point():
     point = Point([1, 2])
@@ -100,6 +108,17 @@ def test_polygon_array():
     np.testing.assert_equal(polygons.area, [9.0, 8.0, -1.0])
     assert polygons.total_bounds == (0.0, 0.0, 3.0, 3.0)
 
+def test_polygon_array_from_exterior_coords():
+    from shapely import Polygon
+    p = Polygon(sample_polygon_exterior)
+
+    for n in range(1, 4):
+        pa_from_shapely = PolygonArray([p for j in range(n)])
+
+        pa_from_coords = PolygonArray.from_exterior_coords([sample_polygon_exterior for j in range(n)])
+
+        assert np.all(pa_from_shapely == pa_from_coords)
+
 
 def test_multipolygon():
     multipolygon = MultiPolygon([
@@ -122,3 +141,15 @@ def test_multipolygon_array():
     np.testing.assert_equal(multipolygon.length, [28.0, 12.0])
     np.testing.assert_equal(multipolygon.area, [17.0, 9.0])
     assert multipolygon.total_bounds == (0.0, 0.0, 11.0, 11.0)
+
+def test_multipolygon_array_from_exterior_coords():
+    from shapely import Polygon, MultiPolygon
+    p = Polygon(sample_polygon_exterior)
+    mp = MultiPolygon([p, p])
+
+    for n in range(1, 4):
+        pa_from_shapely = MultiPolygonArray([mp for j in range(n)])
+
+        pa_from_coords = MultiPolygonArray.from_exterior_coords([[sample_polygon_exterior, sample_polygon_exterior] for j in range(n)])
+
+        assert np.all(pa_from_shapely == pa_from_coords)


### PR DESCRIPTION
Closes #122 

## Overview
- Introduces the `PolygonArray.from_exterior_coords()` and `MultiPolygonArray.from_exterior_coords()` class methods, which take-in an list/array of exterior coordinates equivalent to the following which are derived from Shapely Polygons/MultiPolygons

https://github.com/holoviz/spatialpandas/blob/dd941f2f5f6994c6f09996e9b8af315e16d00051/spatialpandas/geometry/polygon.py#L40-L42

https://github.com/holoviz/spatialpandas/blob/dd941f2f5f6994c6f09996e9b8af315e16d00051/spatialpandas/geometry/multipolygon.py#L40-L48

## Usage

In [UXarray](https://github.com/UXARRAY/uxarray), we use SpatialPandas paired with Datashader to visualize geoscience data that resides on unstructured grids as Polygons. Our unstructured grid is represented as a set of connectivity and coordinate arrays, which we would like to avoid needing to convert to Shapely, because we can derive the exterior of each Polygon quickly using the connectivity and coordinate information. 

## Performance Comparison
_Initial benchmarks, comparing across `n_polygon` & `n_vertices`_

All benchmarks are run on an [NCAR Casper HPC Node](https://arc.ucar.edu/knowledge_base/70549550), with 4 CPU Threads and 128gb of Memory

## Test 1
(40,000,000 Closed Polygons with 7 total verticies)

| Method / # of Polygons | 400,000 | 4,000,000 | 40,000,000 | 
| ------------- | ------------- | ------------- | ------------- |
| Construct with Exterior Coord Array  | 1.02s | 9.74s | 97.0s |
| Create Shapely Polygons + Construct with Shapely Polygons |  16.2s | 159s | 1560s
| Only Construct with Shapely Polygons |  15.2s | 149s | 1500s

Roughly a 16x speedup compared to using Shapely