### PR TITLE
Adapt glob to be compatible with the latest fsspec version

### DIFF
--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -347,7 +347,6 @@ def _perform_read_parquet_dask(
     for path in paths:
         if filesystem.isdir(path):
             path = f"{path}/**/*.parquet"
-        import pdb; pdb.set_trace()
         if has_magic(path):
             path = _expand_path(path, filesystem)
         d = ParquetDataset(

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -346,6 +346,7 @@ def _perform_read_parquet_dask(
     datasets = []
     for path in paths:
         if filesystem.isdir(path):
+            path = path.rstrip('/')
             path = f"{path}/**/*.parquet"
         if has_magic(path):
             path = _expand_path(path, filesystem)

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -346,7 +346,8 @@ def _perform_read_parquet_dask(
     datasets = []
     for path in paths:
         if filesystem.isdir(path):
-            path = f"{path}/**.parquet"
+            path = f"{path}/**/*.parquet"
+        import pdb; pdb.set_trace()
         if has_magic(path):
             path = _expand_path(path, filesystem)
         d = ParquetDataset(


### PR DESCRIPTION
The test suite has been broken for a few weeks with:

```
ValueError: Invalid pattern: '**' can only be an entire path component
```

This is due to a recent change in fsspec (https://github.com/fsspec/filesystem_spec/pull/1382), forcing `**` to be used between path separators only. I checked the change with the latest version of fsspec and a version before this breaking change, it works fine in both cases.

I believe spatialpandas will need a new release.