### PR TITLE
Support Pandas 2.2, unpin Pyarrow, and fail on warnings in tests

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,7 @@ lint = ["py311", "lint"]
 dask-core = "*"
 fsspec = "*"
 numba = "*"
+packaging = "*"
 pandas = "*"
 pip = "*"
 pyarrow = ">=10,<15" # FIX: Temporary upper pin

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,7 @@ numba = "*"
 packaging = "*"
 pandas = "*"
 pip = "*"
-pyarrow = ">=10,<15" # FIX: Temporary upper pin
+pyarrow = ">=10"
 retrying = "*"
 
 [feature.py39.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,7 +24,7 @@ lint = ["py311", "lint"]
 dask-core = "*"
 fsspec = "*"
 numba = "*"
-pandas = "<2.2" # FIX: Temporary upper pin
+pandas = "*"
 pip = "*"
 pyarrow = ">=10,<15" # FIX: Temporary upper pin
 retrying = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ addopts = [
 minversion = "7"
 xfail_strict = true
 log_cli_level = "INFO"
-filterwarnings = []
+filterwarnings = [
+    "error",
+]
 
 [tool.ruff]
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ addopts = [
 minversion = "7"
 xfail_strict = true
 log_cli_level = "INFO"
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "ignore:datetime.datetime.utcnow():DeprecationWarning:botocore", # https://github.com/boto/boto3/issues/3889
+]
 
 [tool.ruff]
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,15 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
 ]
-dependencies = ['dask', 'fsspec >=2022.8', 'numba', 'pandas', 'pyarrow >=10', 'retrying']
+dependencies = [
+    'dask',
+    'fsspec >=2022.8',
+    'numba',
+    'packaging',
+    'pandas',
+    'pyarrow >=10',
+    'retrying',
+]
 
 [project.urls]
 Homepage = "https://github.com/holoviz/spatialpandas"
@@ -61,9 +69,7 @@ addopts = [
 minversion = "7"
 xfail_strict = true
 log_cli_level = "INFO"
-filterwarnings = [
-    "error",
-]
+filterwarnings = ["error"]
 
 [tool.ruff]
 fix = true

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -190,7 +190,11 @@ class DaskGeoDataFrame(dd.DataFrame):
 
         # Set index to distance. This will trigger an expensive shuffle
         # sort operation
-        ddf = ddf.set_index('hilbert_distance', npartitions=npartitions, shuffle=shuffle)
+        try:
+            ddf = ddf.set_index('hilbert_distance', npartitions=npartitions, shuffle_method=shuffle)
+        except TypeError:
+            # Changed to shuffle_method in 2024.1, https://github.com/dask/dask/pull/10738
+            ddf = ddf.set_index('hilbert_distance', npartitions=npartitions, shuffle=shuffle)
 
         if ddf.npartitions != npartitions:
             # set_index doesn't change the number of partitions if the partitions

--- a/spatialpandas/geodataframe.py
+++ b/spatialpandas/geodataframe.py
@@ -67,7 +67,10 @@ class GeoDataFrame(pd.DataFrame):
         if not any(isinstance(block.dtype, GeometryDtype) for block in mgr.blocks):
             return pd.DataFrame._from_mgr(mgr, axes)
 
-        return GeoDataFrame._from_mgr(mgr, axes)
+        gdf = GeoDataFrame._from_mgr(mgr, axes)
+        if (gdf.columns == "geometry").sum() == 1:  # only if "geometry" is single col
+            gdf._geometry = "geometry"
+        return gdf
 
     @property
     def _constructor_sliced(self):

--- a/spatialpandas/geoseries.py
+++ b/spatialpandas/geoseries.py
@@ -52,6 +52,22 @@ class GeoSeries(pd.Series):
         from .geodataframe import GeoDataFrame
         return GeoDataFrame
 
+    def _constructor_expanddim_from_mgr(self, mgr, axes):
+        from .geodataframe import GeoDataFrame
+        df = pd.DataFrame._from_mgr(mgr, axes)
+        geo_cols = [col for col in df.columns if isinstance(df[col].dtype, GeometryDtype)]
+        if geo_cols:
+            if len(geo_cols) == 1:
+                geo_col_name = geo_cols
+            else:
+                geo_col_name = None
+
+            if geo_col_name is None or not isinstance(getattr(df, "dtype", None), GeometryDtype):
+                df = GeoDataFrame(df)
+            else:
+                df = df.set_geometry(geo_col_name)
+        return df
+
     @property
     def bounds(self):
         return pd.DataFrame(

--- a/spatialpandas/geoseries.py
+++ b/spatialpandas/geoseries.py
@@ -57,12 +57,9 @@ class GeoSeries(pd.Series):
         df = pd.DataFrame._from_mgr(mgr, axes)
         geo_cols = [col for col in df.columns if isinstance(df[col].dtype, GeometryDtype)]
         if geo_cols:
-            if len(geo_cols) == 1:
-                geo_col_name = geo_cols
-            else:
-                geo_col_name = None
+            geo_col_name = geo_cols if len(geo_cols) == 1 else None
 
-            if geo_col_name is None or not isinstance(getattr(df, "dtype", None), GeometryDtype):
+            if geo_col_name is None or not isinstance(getattr(df[geo_col_name], "dtype", None), GeometryDtype):
                 df = GeoDataFrame(df)
             else:
                 df = df.set_geometry(geo_col_name)

--- a/spatialpandas/tests/geometry/strategies.py
+++ b/spatialpandas/tests/geometry/strategies.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 from geopandas import GeoSeries
 from geopandas.array import from_shapely
@@ -11,7 +12,7 @@ from shapely.ops import unary_union, polygonize
 
 hyp_settings = settings(
     deadline=None,
-    max_examples=100,
+    max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 100)),
     suppress_health_check=[HealthCheck.too_slow],
 )
 

--- a/spatialpandas/tests/spatialindex/test_hilbert_curve.py
+++ b/spatialpandas/tests/spatialindex/test_hilbert_curve.py
@@ -1,3 +1,4 @@
+import os
 from itertools import product
 
 import hypothesis.strategies as st
@@ -18,7 +19,7 @@ from spatialpandas.spatialindex.hilbert_curve import (
     distances_from_coordinates,
 )
 
-hyp_settings = settings(deadline=None)
+hyp_settings = settings(deadline=None, max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 100)))
 
 # ### strategies ###
 st_p = st.integers(min_value=1, max_value=5)

--- a/spatialpandas/tests/spatialindex/test_rtree.py
+++ b/spatialpandas/tests/spatialindex/test_rtree.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 
 import hypothesis.strategies as st
@@ -9,7 +10,7 @@ from hypothesis.extra.numpy import arrays
 from spatialpandas.spatialindex import HilbertRtree
 
 # ### hypothesis settings ###
-hyp_settings = settings(deadline=None)
+hyp_settings = settings(deadline=None, max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 100)))
 
 
 # ### Custom strategies ###

--- a/spatialpandas/tests/test_fixedextensionarray.py
+++ b/spatialpandas/tests/test_fixedextensionarray.py
@@ -1,5 +1,7 @@
+import itertools
 import pandas.tests.extension.base as eb
 import pytest
+import pandas as pd
 
 from spatialpandas.geometry import PointArray, PointDtype
 
@@ -288,3 +290,72 @@ class TestGeometryReshaping(eb.BaseReshapingTests):
     @pytest.mark.skip(reason="transpose with numpy array elements seems not supported")
     def test_transpose(self):
         pass
+
+    # NOTE: this test is copied from pandas/tests/extension/base/reshaping.py
+    # because starting with pandas 3.0 the assert_frame_equal is strict regarding
+    # the exact missing value (None vs NaN)
+    # Our `result` uses None, but the way the `expected` is created results in
+    # NaNs (and specifying to use None as fill value in unstack also does not
+    # help)
+    # -> the only real change compared to the upstream test is marked
+    # Change from: https://github.com/geopandas/geopandas/pull/3234
+    @pytest.mark.parametrize(
+            "index",
+        [
+            # Two levels, uniform.
+            pd.MultiIndex.from_product(([["A", "B"], ["a", "b"]]), names=["a", "b"]),
+            # non-uniform
+            pd.MultiIndex.from_tuples([("A", "a"), ("A", "b"), ("B", "b")]),
+            # three levels, non-uniform
+            pd.MultiIndex.from_product([("A", "B"), ("a", "b", "c"), (0, 1, 2)]),
+            pd.MultiIndex.from_tuples(
+                [
+                    ("A", "a", 1),
+                    ("A", "b", 0),
+                    ("A", "a", 0),
+                    ("B", "a", 0),
+                    ("B", "c", 1),
+                ]
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("obj", ["series", "frame"])
+    def test_unstack(self, data, index, obj):
+        data = data[: len(index)]
+        if obj == "series":
+            ser = pd.Series(data, index=index)
+        else:
+            ser = pd.DataFrame({"A": data, "B": data}, index=index)
+
+        n = index.nlevels
+        levels = list(range(n))
+        # [0, 1, 2]
+        # [(0,), (1,), (2,), (0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
+        combinations = itertools.chain.from_iterable(
+            itertools.permutations(levels, i) for i in range(1, n)
+        )
+
+        for level in combinations:
+            result = ser.unstack(level=level)
+            assert all(
+                isinstance(result[col].array, type(data)) for col in result.columns
+            )
+
+            if obj == "series":
+                # We should get the same result with to_frame+unstack+droplevel
+                df = ser.to_frame()
+
+                alt = df.unstack(level=level).droplevel(0, axis=1)
+                pd.testing.assert_frame_equal(result, alt)
+
+            obj_ser = ser.astype(object)
+
+            expected = obj_ser.unstack(level=level, fill_value=data.dtype.na_value)
+            if obj == "series":
+                assert (expected.dtypes == object).all()  # noqa: E721
+            # <------------ next line is added
+            expected[expected.isna()] = None
+            # ------------->
+
+            result = result.astype(object)
+            pd.testing.assert_frame_equal(result, expected)

--- a/spatialpandas/tests/test_fixedextensionarray.py
+++ b/spatialpandas/tests/test_fixedextensionarray.py
@@ -276,6 +276,9 @@ class TestGeometryMissing(eb.BaseMissingTests):
     def test_fillna_series_method(self):
         pass
 
+    @pytest.mark.skip(reason="not implemented")
+    def test_ffill_limit_area(self):
+        pass
 
 class TestGeometryReshaping(eb.BaseReshapingTests):
     @pytest.mark.skip(reason="__setitem__ not supported")

--- a/spatialpandas/tests/test_listextensionarray.py
+++ b/spatialpandas/tests/test_listextensionarray.py
@@ -1,5 +1,7 @@
+import itertools
 import pandas.tests.extension.base as eb
 import pytest
+import pandas as pd
 
 from spatialpandas.geometry import LineArray, LineDtype
 
@@ -288,3 +290,72 @@ class TestGeometryReshaping(eb.BaseReshapingTests):
     @pytest.mark.skip(reason="transpose with numpy array elements seems not supported")
     def test_transpose(self):
         pass
+
+    # NOTE: this test is copied from pandas/tests/extension/base/reshaping.py
+    # because starting with pandas 3.0 the assert_frame_equal is strict regarding
+    # the exact missing value (None vs NaN)
+    # Our `result` uses None, but the way the `expected` is created results in
+    # NaNs (and specifying to use None as fill value in unstack also does not
+    # help)
+    # -> the only real change compared to the upstream test is marked
+    # Change from: https://github.com/geopandas/geopandas/pull/3234
+    @pytest.mark.parametrize(
+            "index",
+        [
+            # Two levels, uniform.
+            pd.MultiIndex.from_product(([["A", "B"], ["a", "b"]]), names=["a", "b"]),
+            # non-uniform
+            pd.MultiIndex.from_tuples([("A", "a"), ("A", "b"), ("B", "b")]),
+            # three levels, non-uniform
+            pd.MultiIndex.from_product([("A", "B"), ("a", "b", "c"), (0, 1, 2)]),
+            pd.MultiIndex.from_tuples(
+                [
+                    ("A", "a", 1),
+                    ("A", "b", 0),
+                    ("A", "a", 0),
+                    ("B", "a", 0),
+                    ("B", "c", 1),
+                ]
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("obj", ["series", "frame"])
+    def test_unstack(self, data, index, obj):
+        data = data[: len(index)]
+        if obj == "series":
+            ser = pd.Series(data, index=index)
+        else:
+            ser = pd.DataFrame({"A": data, "B": data}, index=index)
+
+        n = index.nlevels
+        levels = list(range(n))
+        # [0, 1, 2]
+        # [(0,), (1,), (2,), (0, 1), (0, 2), (1, 0), (1, 2), (2, 0), (2, 1)]
+        combinations = itertools.chain.from_iterable(
+            itertools.permutations(levels, i) for i in range(1, n)
+        )
+
+        for level in combinations:
+            result = ser.unstack(level=level)
+            assert all(
+                isinstance(result[col].array, type(data)) for col in result.columns
+            )
+
+            if obj == "series":
+                # We should get the same result with to_frame+unstack+droplevel
+                df = ser.to_frame()
+
+                alt = df.unstack(level=level).droplevel(0, axis=1)
+                pd.testing.assert_frame_equal(result, alt)
+
+            obj_ser = ser.astype(object)
+
+            expected = obj_ser.unstack(level=level, fill_value=data.dtype.na_value)
+            if obj == "series":
+                assert (expected.dtypes == object).all()  # noqa: E721
+            # <------------ next line is added
+            expected[expected.isna()] = None
+            # ------------->
+
+            result = result.astype(object)
+            pd.testing.assert_frame_equal(result, expected)

--- a/spatialpandas/tests/test_listextensionarray.py
+++ b/spatialpandas/tests/test_listextensionarray.py
@@ -275,6 +275,9 @@ class TestGeometryMissing(eb.BaseMissingTests):
     def test_fillna_series_method(self):
         pass
 
+    @pytest.mark.skip(reason="not implemented")
+    def test_ffill_limit_area(self):
+        pass
 
 
 class TestGeometryReshaping(eb.BaseReshapingTests):

--- a/spatialpandas/tests/test_parquet.py
+++ b/spatialpandas/tests/test_parquet.py
@@ -1,3 +1,5 @@
+import os
+
 import dask
 import dask.dataframe as dd
 import hypothesis.strategies as hs
@@ -21,7 +23,7 @@ dask.config.set(scheduler="single-threaded")
 
 hyp_settings = settings(
     deadline=None,
-    max_examples=100,
+    max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 100)),
     suppress_health_check=[HealthCheck.too_slow],
 )
 
@@ -133,7 +135,7 @@ def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path_factory):
     gp_multipoint=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
     gp_multiline=st_multiline_array(min_size=10, max_size=40, geoseries=True),
 )
-@settings(deadline=None, max_examples=30)
+@settings(deadline=None, max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 30)))
 def test_pack_partitions(gp_multipoint, gp_multiline):
     # Build dataframe
     n = min(len(gp_multipoint), len(gp_multiline))
@@ -172,7 +174,7 @@ def test_pack_partitions(gp_multipoint, gp_multiline):
 )
 @settings(
     deadline=None,
-    max_examples=30,
+    max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 30)),
     suppress_health_check=[HealthCheck.too_slow],
     phases=[
         Phase.explicit,
@@ -246,7 +248,7 @@ def test_pack_partitions_to_parquet(gp_multipoint, gp_multiline,
     gp_multipoint2=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
     gp_multiline2=st_multiline_array(min_size=10, max_size=40, geoseries=True),
 )
-@settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+@settings(deadline=None, max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 30)), suppress_health_check=[HealthCheck.too_slow])
 def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
                                          gp_multipoint2, gp_multiline2,
                                          tmp_path_factory):
@@ -316,7 +318,7 @@ def test_pack_partitions_to_parquet_glob(gp_multipoint1, gp_multiline1,
     gp_multiline2=st_multiline_array(min_size=10, max_size=40, geoseries=True),
     bounds=st_bounds(),
 )
-@settings(deadline=None, max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+@settings(deadline=None, max_examples=int(os.environ.get('HYPOTHESIS_MAX_EXAMPLES', 30)), suppress_health_check=[HealthCheck.too_slow])
 def test_pack_partitions_to_parquet_list_bounds(
         gp_multipoint1, gp_multiline1,
         gp_multipoint2, gp_multiline2,


### PR DESCRIPTION
Fixes #137

The pandas 2.2 compatibility changes are almost the same as those done in GeoPandas:
- https://github.com/geopandas/geopandas/pull/3046
- https://github.com/geopandas/geopandas/pull/3080
- https://github.com/geopandas/geopandas/pull/3234
- https://github.com/geopandas/geopandas/pull/3173

The dask warning was added in dask 2024.1:
- https://github.com/dask/dask/pull/10738

Removed legacy pyarrow support as we now lower pin to version 10

I have also added `HYPOTHESIS_MAX_EXAMPLES` to make it easier to test locally. 

Added `packaging` as a required dependency.