### PR TITLE
compat: Ensure that pandas dtype matches dask when loading data from parquet

### DIFF
--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -144,7 +144,7 @@ def read_parquet(
     # References:
     # https://arrow.apache.org/docs/python/pandas.html
     # https://pandas.pydata.org/docs/user_guide/pyarrow.html
-    type_mapping = {pa.string(): pd.StringDtype("pyarrow")} if convert_string else {}
+    type_mapping = {pa.string(): pd.StringDtype("pyarrow"), pa.large_string(): pd.StringDtype("pyarrow")} if convert_string else {}
     df = dataset.read(columns=columns).to_pandas(types_mapper=type_mapping.get, self_destruct=True)
 
     # Return result

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -144,7 +144,6 @@ def read_parquet(
     # References:
     # https://arrow.apache.org/docs/python/pandas.html
     # https://pandas.pydata.org/docs/user_guide/pyarrow.html
-    # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
     type_mapping = {pa.string(): pd.StringDtype("pyarrow")} if convert_string else {}
     df = dataset.read(columns=columns).to_pandas(types_mapper=type_mapping.get)
 
@@ -339,6 +338,7 @@ def _perform_read_parquet_dask(
         dataset_pieces = sorted(fragments, key=lambda piece: natural_sort_key(piece.path))
         pieces.extend(dataset_pieces)
 
+    # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
     try:
         from dask.dataframe.utils import pyarrow_strings_enabled
 

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -145,7 +145,7 @@ def read_parquet(
     # https://arrow.apache.org/docs/python/pandas.html
     # https://pandas.pydata.org/docs/user_guide/pyarrow.html
     type_mapping = {pa.string(): pd.StringDtype("pyarrow")} if convert_string else {}
-    df = dataset.read(columns=columns).to_pandas(types_mapper=type_mapping.get)
+    df = dataset.read(columns=columns).to_pandas(types_mapper=type_mapping.get, self_destruct=True)
 
     # Return result
     return GeoDataFrame(df)

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -457,7 +457,7 @@ def _perform_read_parquet_dask(
     if delayed_partitions:
         result = from_delayed(
             delayed_partitions, divisions=divisions, meta=meta, verify_meta=False
-        )
+        ).astype(meta.dtypes)
     else:
         # Single partition empty result
         result = from_pandas(meta, npartitions=1)

--- a/spatialpandas/tests/test_parquet.py
+++ b/spatialpandas/tests/test_parquet.py
@@ -440,3 +440,7 @@ def test_read_parquet_dask(directory, repartitioned):
     assert partition_bounds["multiline"].index.name == "partition"
     assert ddf["multiline"].partition_bounds.index.name == "partition"
     assert all(partition_bounds["multiline"] == ddf["multiline"].partition_bounds)
+
+def test_parquet_dask_string_conversion():
+    from dask.dataframe.utils import pyarrow_strings_enabled
+    assert isinstance(pyarrow_strings_enabled(), bool)


### PR DESCRIPTION
It makes it so that the following will give the same types before it returned `(string[pyarrow], object)`.

``` python
import dask
import spatialpandas.io as sio

dask.config.set({"dataframe.convert-string": True})

# http://s3.amazonaws.com/datashader-data/nyc_buildings.parq.zip
ddf = sio.read_parquet_dask("./data/nyc_buildings.parq")
ddf["type"].dtype, ddf["type"].compute().dtype
```

Together with https://github.com/holoviz/holoviews/pull/6362 should make it possible to run the NYC Buildings example.  