### PR TITLE
Update resolution for floats in tests

### DIFF
--- a/spatialpandas/tests/geometry/strategies.py
+++ b/spatialpandas/tests/geometry/strategies.py
@@ -16,9 +16,11 @@ hyp_settings = settings(
     suppress_health_check=[HealthCheck.too_slow],
 )
 
+resolution = abs(int(np.abs(np.log10(np.finfo(1.0).resolution))))
+
 coord = st.floats(
     allow_infinity=False, allow_nan=False, max_value=1000, min_value=-1000,
-).map(lambda x: round(x, 15))
+).map(lambda x: round(x, resolution - 1))
 
 st_points = arrays(
     elements=st.floats(


### PR DESCRIPTION
Fixes https://github.com/holoviz/spatialpandas/issues/152

The original example came down to this:

```
ax0 = 1.0
ay0 = -16.0
ax1 = 0.0
ay1 = 0.0

bx0 = 0.0
by0 = -1e-15
bx1 = 0.0
by1 = -1.0

triangle_orientation(ax0, -16.0, ax1, ay1, bx0, by0), triangle_orientation(ax0, -17.0, ax1, ay1, bx0, by0)  #Returns True, False
```

Which could further be reduced to this precision problem:
![image](https://github.com/user-attachments/assets/79c033d9-5876-4193-a20e-3639913c144c)

Now, we round the floats to one above the computer precision of numpy floats (for me, 15). 
