### PR TITLE
test: Don't compare line length of zero size

### DIFF
--- a/spatialpandas/tests/geometry/algorithms/test_intersection.py
+++ b/spatialpandas/tests/geometry/algorithms/test_intersection.py
@@ -70,6 +70,8 @@ def test_segment_intersection(ax0, ay0, ax1, ay1, bx0, by0, bx1, by1):
         return
     line1 = sg.LineString([(ax0, ay0), (ax1, ay1)])
     line2 = sg.LineString([(bx0, by0), (bx1, by1)])
+    if line1.length == 0 or line2.length == 0:
+        return
     expected = line1.intersects(line2)
     assert result1 == expected
 


### PR DESCRIPTION
Seeing this test fail regularly, with input as not being a line but only a point

![image](https://github.com/user-attachments/assets/457da09f-22b2-4ec6-9424-a6f106f5d336)
