### PR TITLE
bug: use find_spec for spatialpandas.dask import

### DIFF
--- a/spatialpandas/__init__.py
+++ b/spatialpandas/__init__.py
@@ -1,18 +1,16 @@
+from importlib.util import find_spec
+
 from . import geometry, spatialindex, tools
 from .__version import __version__
 from .geodataframe import GeoDataFrame
 from .geoseries import GeoSeries
 from .tools.sjoin import sjoin
 
-try:
-    import dask.dataframe  # noqa
-
+if find_spec("dask"):
     # Import to trigger registration of types with Dask
     import spatialpandas.dask  # noqa
-except ImportError:
-    # Dask dataframe not available
-    pass
 
+del find_spec
 
 __all__ = [
     "GeoDataFrame",


### PR DESCRIPTION
Previous if some import failed in `import spatialpandas.dask` there was no way to see it. It was leading to weird behavior.