### PR TITLE
compat: Upper pin Dask

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -21,9 +21,9 @@ build = ["py311", "build"]
 lint = ["py311", "lint"]
 
 [dependencies]
+numba = "*"
 dask-core = "<2025.1"  # TODO: Does not work with new DataFrame interface
 fsspec = "*"
-numba = "*"
 packaging = "*"
 pandas = "*"
 pip = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,7 @@ build = ["py311", "build"]
 lint = ["py311", "lint"]
 
 [dependencies]
-dask-core = "*"
+dask-core = "<2025.1"  # TODO: Does not work with new DataFrame interface
 fsspec = "*"
 numba = "*"
 packaging = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    'dask',
+    'dask <2025.1',
     'fsspec >=2022.8',
     'numba',
     'packaging',


### PR DESCRIPTION
The classic dask.dataframe implementation no longer works; this adds an upper pin for the last version that supported it. This makes our test fail

![image](https://github.com/user-attachments/assets/4f6d17f5-56e0-4d95-94d1-2e798452cb1b)

https://github.com/holoviz/spatialpandas/actions/runs/12849469027/job/35828212336

It can be removed when https://github.com/holoviz/spatialpandas/issues/146 is merged.