### PR TITLE
compat!: Support dask query-planning, drop Python 3.9, update pins

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-39", "test-312"]
+              "environment": ["test-310", "test-312"]
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'full' option
@@ -91,7 +91,7 @@ jobs:
         run: |
           MATRIX=$(jq -nsc '{
               "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-              "environment": ["test-39", "test-310", "test-311", "test-312"]
+              "environment": ["test-310", "test-311", "test-312"]
           }')
           echo "MATRIX=$MATRIX" >> $GITHUB_ENV
       - name: Set test matrix with 'downstream' option

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,11 +8,9 @@ install = 'python -m pip install --no-deps --disable-pip-version-check -e .'
 
 [activation.env]
 PYTHONIOENCODING = "utf-8"
-DASK_DATAFRAME__QUERY_PLANNING = "False" # TODO: Support query planning
 USE_PYGEOS = '0'
 
 [environments]
-test-39 = ["py39", "test-core", "test", "test-task", "example", "test-example"]
 test-310 = ["py310", "test-core", "test", "test-task", "example", "test-example"]
 test-311 = ["py311", "test-core", "test", "test-task", "example", "test-example"]
 test-312 = ["py312", "test-core", "test", "test-task", "example", "test-example"]
@@ -22,16 +20,13 @@ lint = ["py311", "lint"]
 
 [dependencies]
 numba = "*"
-dask-core = "<2025.1"  # TODO: Does not work with new DataFrame interface
+dask-core = ">=2025.1"
 fsspec = "*"
 packaging = "*"
 pandas = "*"
 pip = "*"
 pyarrow = ">=10"
 retrying = "*"
-
-[feature.py39.dependencies]
-python = "3.9.*"
 
 [feature.py310.dependencies]
 python = "3.10.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,9 +23,9 @@ numba = "*"
 dask-core = ">=2025.1"
 fsspec = "*"
 packaging = "*"
-pandas = "*"
+pandas = ">=2.0"
 pip = "*"
-pyarrow = ">=10"
+pyarrow = ">=14.0.1"
 retrying = "*"
 
 [feature.py310.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -81,6 +81,9 @@ test-unit = 'pytest spatialpandas/tests -n logical --dist loadgroup'
 [feature.test-example.dependencies]
 nbval = "*"
 
+[feature.test-example.activation.env]
+DASK_SCHEDULER = "single-threaded"
+
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    'dask <2025.1',
+    'dask >=2025.1',
     'fsspec >=2022.8',
     'numba',
     'packaging',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ filterwarnings = [
 [tool.ruff]
 fix = true
 line-length = 100
+target-version = "py39"  # TODO: Remove in follow up PR
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,14 @@ filterwarnings = [
     "ignore:datetime.datetime.utcnow():DeprecationWarning:botocore", # https://github.com/boto/boto3/issues/3889
     # 2024-11
     "ignore:The legacy Dask DataFrame implementation is deprecated:FutureWarning", # https://github.com/holoviz/spatialpandas/issues/146
+    # 2025-02
+    "ignore:Dask annotations ..retries.. 5. detected:UserWarning", # https://github.com/dask/dask/issues/11721
 ]
 
 [tool.ruff]
 fix = true
 line-length = 100
-target-version = "py39"  # TODO: Remove in follow up PR
+target-version = "py39" # TODO: Remove in follow up PR
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
     'fsspec >=2022.8',
     'numba',
     'packaging',
-    'pandas',
-    'pyarrow >=10',
+    'pandas >=2.0',
+    'pyarrow >=14.0.1',
     'retrying',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,13 @@ dynamic = ["version"]
 description = 'Pandas extension arrays for spatial/geometric operations'
 readme = "README.md"
 license = { text = "BSD-2-Clause" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "HoloViz developers", email = "developers@holoviz.org" }]
 maintainers = [{ name = "HoloViz developers", email = "developers@holoviz.org" }]
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -316,8 +316,7 @@ class DaskGeoDataFrame(dd.DataFrame):
         ddf = self._with_hilbert_distance_column(p)
 
         # Compute output hilbert_distance divisions
-        from dask.dataframe.partitionquantiles import partition_quantiles
-        quantiles = partition_quantiles(
+        quantiles = dd.partitionquantiles(
             ddf.hilbert_distance, npartitions
         ).compute().values
 

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -13,15 +13,9 @@ import pyarrow.parquet as pq
 from dask import delayed
 from dask.dataframe.core import get_parallel_type
 from dask.dataframe.extensions import make_array_nonempty
-from dask.dataframe.partitionquantiles import partition_quantiles
+from dask.dataframe.utils import make_meta as make_meta_dispatch, meta_nonempty
 from packaging.version import Version
 from retrying import retry
-
-try:
-    from dask.dataframe.backends import meta_nonempty
-    from dask.dataframe.dispatch import make_meta_dispatch
-except ImportError:
-    from dask.dataframe.utils import make_meta as make_meta_dispatch, meta_nonempty
 
 from .geodataframe import GeoDataFrame
 from .geometry.base import GeometryDtype, _BaseCoordinateIndexer
@@ -312,6 +306,7 @@ class DaskGeoDataFrame(dd.DataFrame):
         ddf = self._with_hilbert_distance_column(p)
 
         # Compute output hilbert_distance divisions
+        from dask.dataframe.partitionquantiles import partition_quantiles
         quantiles = partition_quantiles(
             ddf.hilbert_distance, npartitions
         ).compute().values

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -13,7 +13,7 @@ import pyarrow.parquet as pq
 from dask import delayed
 from dask.dataframe.core import get_parallel_type
 from dask.dataframe.extensions import make_array_nonempty
-from dask.dataframe.utils import make_meta as make_meta_dispatch, meta_nonempty
+from dask.dataframe.utils import make_meta_obj, meta_nonempty
 from packaging.version import Version
 from retrying import retry
 
@@ -24,6 +24,9 @@ from .spatialindex import HilbertRtree
 
 
 class DaskGeoSeries(dd.Series):
+
+    _partition_type = GeoSeries
+
     def __init__(self, dsk, name, meta, divisions, *args, **kwargs):
         super().__init__(dsk, name, meta, divisions)
 
@@ -99,7 +102,7 @@ class DaskGeoSeries(dd.Series):
         )
 
 
-@make_meta_dispatch(GeoSeries)
+@make_meta_obj.register(GeoSeries)
 def make_meta_series(s, index=None):
     result = s.head(0)
     if index is not None:
@@ -118,6 +121,8 @@ def get_parallel_type_dataframe(df):
 
 
 class DaskGeoDataFrame(dd.DataFrame):
+    _partition_type = GeoDataFrame
+
     def __init__(self, dsk, name, meta, divisions):
         super().__init__(dsk, name, meta, divisions)
         self._partition_sindex = {}
@@ -579,7 +584,7 @@ class DaskGeoDataFrame(dd.DataFrame):
         return result
 
 
-@make_meta_dispatch(GeoDataFrame)
+@make_meta_obj.register(GeoDataFrame)
 def make_meta_dataframe(df, index=None):
     result = df.head(0)
     if index is not None:

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -24,9 +24,6 @@ from .spatialindex import HilbertRtree
 
 
 class DaskGeoSeries(dd.Series):
-
-    _partition_type = GeoSeries
-
     def __init__(self, expr, *args, **kwargs):
         super().__init__(expr, *args, **kwargs)
 
@@ -128,8 +125,6 @@ def get_collection_type_series(df):
 
 
 class DaskGeoDataFrame(dd.DataFrame):
-    _partition_type = GeoDataFrame
-
     def __init__(self, expr, *args, **kwargs):
         super().__init__(expr, *args, **kwargs)
         self._partition_sindex = {}

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -104,6 +104,8 @@ class DaskGeoSeries(dd.Series):
 
 @make_meta_obj.register(GeoSeries)
 def make_meta_series(s, index=None):
+    if hasattr(s, "__array__") or isinstance(s, np.ndarray):
+        return s[:0]
     result = s.head(0)
     if index is not None:
         result = result.reindex(index[:0])
@@ -591,6 +593,8 @@ class DaskGeoDataFrame(dd.DataFrame):
 
 @make_meta_obj.register(GeoDataFrame)
 def make_meta_dataframe(df, index=None):
+    if hasattr(df, "__array__") or isinstance(df, np.ndarray):
+        return df[:0]
     result = df.head(0)
     if index is not None:
         result = result.reindex(index[:0])

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -99,7 +99,7 @@ class DaskGeoSeries(dd.Series):
         )
 
 
-@make_meta_dispatch.register(GeoSeries)
+@make_meta_dispatch(GeoSeries)
 def make_meta_series(s, index=None):
     result = s.head(0)
     if index is not None:
@@ -579,7 +579,7 @@ class DaskGeoDataFrame(dd.DataFrame):
         return result
 
 
-@make_meta_dispatch.register(GeoDataFrame)
+@make_meta_dispatch(GeoDataFrame)
 def make_meta_dataframe(df, index=None):
     result = df.head(0)
     if index is not None:

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -27,8 +27,8 @@ class DaskGeoSeries(dd.Series):
 
     _partition_type = GeoSeries
 
-    def __init__(self, dsk, name, meta, divisions, *args, **kwargs):
-        super().__init__(dsk, name, meta, divisions)
+    def __init__(self, expr, *args, **kwargs):
+        super().__init__(expr, *args, **kwargs)
 
         # Init backing properties
         self._partition_bounds = None
@@ -116,15 +116,20 @@ def meta_nonempty_series(s, index=None):
 
 
 @get_parallel_type.register(GeoSeries)
-def get_parallel_type_dataframe(df):
+def get_parallel_type_series(df):
+    return DaskGeoSeries
+
+
+@dd.get_collection_type.register(GeoSeries)
+def get_collection_type_series(df):
     return DaskGeoSeries
 
 
 class DaskGeoDataFrame(dd.DataFrame):
     _partition_type = GeoDataFrame
 
-    def __init__(self, dsk, name, meta, divisions):
-        super().__init__(dsk, name, meta, divisions)
+    def __init__(self, expr, *args, **kwargs):
+        super().__init__(expr, *args, **kwargs)
         self._partition_sindex = {}
         self._partition_bounds = {}
 
@@ -598,9 +603,13 @@ def meta_nonempty_dataframe(df, index=None):
 
 
 @get_parallel_type.register(GeoDataFrame)
-def get_parallel_type_series(s):
+def get_parallel_type_dataframe(s):
     return DaskGeoDataFrame
 
+
+@dd.get_collection_type.register(GeoDataFrame)
+def get_collection_type_dataframe(df):
+    return DaskGeoDataFrame
 
 class _DaskCoordinateIndexer(_BaseCoordinateIndexer):
     def __init__(self, obj, sindex):

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -317,14 +317,14 @@ class DaskGeoDataFrame(dd.DataFrame):
 
         # Compute output hilbert_distance divisions
         from dask.dataframe.dask_expr import RepartitionQuantiles, new_collection
-        quantiles, *_ = dask.compute(
-            new_collection(RepartitionQuantiles(ddf.hilbert_distance, npartitions))
-        )
+        quantiles = new_collection(
+            RepartitionQuantiles(ddf.hilbert_distance, npartitions)
+        ).compute().values
 
         # Add _partition column containing output partition number of each row
         ddf = ddf.map_partitions(
             lambda df: df.assign(
-                _partition=np.digitize(df.hilbert_distance, quantiles.values[1:], right=True))
+                _partition=np.digitize(df.hilbert_distance, quantiles[1:], right=True))
         )
 
         # Compute part paths

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -14,7 +14,6 @@ from dask import delayed
 from dask.dataframe.core import get_parallel_type
 from dask.dataframe.extensions import make_array_nonempty
 from dask.dataframe.utils import make_meta_obj, meta_nonempty
-from packaging.version import Version
 from retrying import retry
 
 from .geodataframe import GeoDataFrame
@@ -192,11 +191,7 @@ class DaskGeoDataFrame(dd.DataFrame):
 
         # Set index to distance. This will trigger an expensive shuffle
         # sort operation
-        if Version(dask.__version__) >= Version('2024.1'):
-            shuffle_kwargs = {'shuffle_method': shuffle}
-        else:
-            shuffle_kwargs = {'shuffle': shuffle}
-        ddf = ddf.set_index('hilbert_distance', npartitions=npartitions, **shuffle_kwargs)
+        ddf = ddf.set_index('hilbert_distance', npartitions=npartitions, shuffle_method=shuffle)
 
         if ddf.npartitions != npartitions:
             # set_index doesn't change the number of partitions if the partitions

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -333,7 +333,7 @@ class DaskGeoDataFrame(dd.DataFrame):
             for out_partition in out_partitions
         ]
         part_output_paths = [
-            os.path.join(path, f"part.{int(out_partition)}.parquet")
+            os.path.join(path, f"part.{out_partition}.parquet")
             for out_partition in out_partitions
         ]
 
@@ -343,7 +343,7 @@ class DaskGeoDataFrame(dd.DataFrame):
             rm_retry(path)
 
         for out_partition in out_partitions:
-            part_dir = os.path.join(path, f"part.{int(out_partition)}.parquet" )
+            part_dir = os.path.join(path, f"part.{out_partition}.parquet" )
             mkdirs_retry(part_dir)
             tmp_part_dir = tempdir_format.format(partition=out_partition, uuid=dataset_uuid)
             mkdirs_retry(tmp_part_dir)
@@ -365,7 +365,7 @@ class DaskGeoDataFrame(dd.DataFrame):
             for out_partition, df_part in df.groupby('_partition'):
                 part_path = os.path.join(
                     tempdir_format.format(partition=out_partition, uuid=dataset_uuid),
-                    f'part{int(i)}.parquet',
+                    f'part{i}.parquet',
                 )
                 df_part = (
                     df_part

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -177,7 +177,7 @@ def to_parquet_dask(
         warnings.filterwarnings(
             "ignore",
             category=UserWarning,
-            message="Dask annotations .* detected. Annotations will be ignored when using query-planning.",
+            message="Dask annotations {'retries': 5} detected",
         )
         dd_to_parquet(
             ddf,

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -79,18 +79,16 @@ def to_parquet(
         filesystem = validate_coerce_filesystem(path, filesystem, storage_options)
 
     # Standard pandas to_parquet with pyarrow engine
-    to_parquet_args = {
-        "df": df,
-        "path": path,
-        "engine": "pyarrow",
-        "compression": compression,
-        "filesystem": filesystem,
-        "index": index,
-        "storage_options": storage_options,
+    pd_to_parquet(
+        df=df,
+        path=path,
+        engine="pyarrow",
+        compression=compression,
+        filesystem=filesystem,
+        index=index,
+        storage_options=storage_options,
         **kwargs,
-    }
-
-    pd_to_parquet(**to_parquet_args)
+    )
 
 
 def read_parquet(

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -1,5 +1,4 @@
 import json
-import warnings
 from collections.abc import Iterable
 from functools import reduce
 from glob import has_magic
@@ -172,24 +171,17 @@ def to_parquet_dask(
     spatial_metadata = {'partition_bounds': partition_bounds}
     b_spatial_metadata = json.dumps(spatial_metadata).encode('utf')
 
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            category=UserWarning,
-            message="Dask annotations {'retries': 5} detected",
-        )
-        dd_to_parquet(
-            ddf,
-            path,
-            engine="pyarrow",
-            compression=compression,
-            storage_options=storage_options,
-            custom_metadata={b'spatialpandas': b_spatial_metadata},
-            write_metadata_file=True,
-            **engine_kwargs,
-            **kwargs,
-        )
+    dd_to_parquet(
+        ddf,
+        path,
+        engine="pyarrow",
+        compression=compression,
+        storage_options=storage_options,
+        custom_metadata={b'spatialpandas': b_spatial_metadata},
+        write_metadata_file=True,
+        **engine_kwargs,
+        **kwargs,
+    )
 
 
 def read_parquet_dask(

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -18,7 +18,6 @@ from dask.dataframe import (
     to_parquet as dd_to_parquet,
 )
 from dask.utils import natural_sort_key
-from packaging.version import Version
 from pandas.io.parquet import to_parquet as pd_to_parquet
 from pyarrow.parquet import ParquetDataset, ParquetFile, read_metadata
 
@@ -30,9 +29,6 @@ from ..io.utils import (
     _maybe_prepend_protocol,
     validate_coerce_filesystem,
 )
-
-# improve pandas compatibility, based on geopandas _compat.py
-PANDAS_GE_12 = Version(pd.__version__) >= Version("1.2.0")
 
 
 def _load_parquet_pandas_metadata(
@@ -91,14 +87,9 @@ def to_parquet(
         "compression": compression,
         "filesystem": filesystem,
         "index": index,
+        "storage_options": storage_options,
         **kwargs,
     }
-
-    if PANDAS_GE_12:
-        to_parquet_args.update({"storage_options": storage_options})
-    elif filesystem is None:
-        filesystem = validate_coerce_filesystem(path, filesystem, storage_options)
-        to_parquet_args.update({"filesystem": filesystem})
 
     pd_to_parquet(**to_parquet_args)
 

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from collections.abc import Iterable
 from functools import reduce
 from glob import has_magic
@@ -180,17 +181,24 @@ def to_parquet_dask(
     spatial_metadata = {'partition_bounds': partition_bounds}
     b_spatial_metadata = json.dumps(spatial_metadata).encode('utf')
 
-    dd_to_parquet(
-        ddf,
-        path,
-        engine="pyarrow",
-        compression=compression,
-        storage_options=storage_options,
-        custom_metadata={b'spatialpandas': b_spatial_metadata},
-        write_metadata_file=True,
-        **engine_kwargs,
-        **kwargs,
-    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=UserWarning,
+            message="Dask annotations .* detected. Annotations will be ignored when using query-planning.",
+        )
+        dd_to_parquet(
+            ddf,
+            path,
+            engine="pyarrow",
+            compression=compression,
+            storage_options=storage_options,
+            custom_metadata={b'spatialpandas': b_spatial_metadata},
+            write_metadata_file=True,
+            **engine_kwargs,
+            **kwargs,
+        )
 
 
 def read_parquet_dask(


### PR DESCRIPTION
Resolves https://github.com/holoviz/spatialpandas/issues/146 
Resolves https://github.com/holoviz/spatialpandas/issues/169



I don't want to support the legacy method, so I'm pinning to 2025.1, the first version with the dask-expr part of the dask library.  This version only supports Python 3.10 and forward.

I haven't done any performance benchmarks. This is only to get spatialpandas to work with dask going forward.

reference: https://docs.dask.org/en/stable/dataframe-extend.html

The main functionality has been tested for both HoloViews and Datashader here:
- https://github.com/holoviz/holoviews/pull/6503
- https://github.com/holoviz/datashader/pull/1405
