### PR TITLE
ci: Add `MALLOC_TRIM_THRESHOLD_` for test-example

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -90,6 +90,7 @@ nbval = "*"
 
 [feature.test-example.activation.env]
 DASK_SCHEDULER = "single-threaded"
+MALLOC_TRIM_THRESHOLD_ = '0'
 
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'


### PR DESCRIPTION
Sometimes the example tests fail, this is an attempt to fix it. 